### PR TITLE
Add support for patching fleet manifests

### DIFF
--- a/config/crds/fleet-addon-config.yaml
+++ b/config/crds/fleet-addon-config.yaml
@@ -32,6 +32,10 @@ spec:
                       This will create Fleet Cluster for each Cluster with the same name. In case the cluster specifies topology.class, the name of the ClusterClass will be added to the Fleet Cluster labels.
                     nullable: true
                     type: boolean
+                  set_owner_references:
+                    description: Setting to disable setting owner references on the created resources
+                    nullable: true
+                    type: boolean
                 type: object
               cluster_class:
                 description: Cluster class controller settings
@@ -44,7 +48,15 @@ spec:
                       This will create Fleet ClusterGroups for each ClusterClaster with the same name.
                     nullable: true
                     type: boolean
+                  set_owner_references:
+                    description: Setting to disable setting owner references on the created resources
+                    nullable: true
+                    type: boolean
                 type: object
+              patch_resource:
+                description: Allow to patch resources, maintaining the desired state.
+                nullable: true
+                type: boolean
             type: object
         required:
         - spec

--- a/src/api/fleet_addon_config.rs
+++ b/src/api/fleet_addon_config.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
     version = "v1alpha1"
 )]
 pub struct FleetAddonConfigSpec {
+    /// Allow to patch resources, maintaining the desired state.
+    pub patch_resource: Option<bool>,
     /// Cluster class controller settings
     pub cluster_class: Option<ClusterClassConfig>,
     /// Cluster controller settings
@@ -21,10 +23,13 @@ impl Default for FleetAddonConfig {
         Self {
             metadata: Default::default(),
             spec: FleetAddonConfigSpec {
+                patch_resource: Some(true),
                 cluster_class: Some(ClusterClassConfig {
+                    set_owner_references: Some(true),
                     enabled: Some(true),
                 }),
                 cluster: Some(ClusterConfig {
+                    set_owner_references: Some(true),
                     enabled: Some(true),
                 }),
             },
@@ -38,6 +43,9 @@ pub struct ClusterClassConfig {
     ///
     /// This will create Fleet ClusterGroups for each ClusterClaster with the same name.
     pub enabled: Option<bool>,
+
+    /// Setting to disable setting owner references on the created resources
+    pub set_owner_references: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
@@ -48,4 +56,7 @@ pub struct ClusterConfig {
     /// In case the cluster specifies topology.class, the name of the ClusterClass
     /// will be added to the Fleet Cluster labels.
     pub enabled: Option<bool>,
+
+    /// Setting to disable setting owner references on the created resources
+    pub set_owner_references: Option<bool>,
 }

--- a/src/controllers/controller.rs
+++ b/src/controllers/controller.rs
@@ -1,11 +1,12 @@
 use crate::api::fleet_addon_config::FleetAddonConfig;
+use crate::controllers::PatchError;
 use crate::metrics::Diagnostics;
 use crate::{telemetry, Error, Metrics};
 use chrono::Utc;
 
 use k8s_openapi::NamespaceResourceScope;
 
-use kube::api::PostParams;
+use kube::api::{Patch, PatchParams, PostParams};
 
 use kube::runtime::events::{Event, EventType};
 use kube::runtime::finalizer;
@@ -80,6 +81,51 @@ where
         })
         .await
         .map_err(GetOrCreateError::Event)?;
+
+    Ok(Action::await_change())
+}
+
+pub(crate) async fn patch<R>(ctx: Arc<Context>, res: R) -> Result<Action, PatchError>
+where
+    R: std::fmt::Debug,
+    R: Clone + Serialize + DeserializeOwned,
+    R: kube::Resource<DynamicType = (), Scope = NamespaceResourceScope>,
+    R: kube::ResourceExt,
+{
+    let ns = res
+        .meta()
+        .namespace
+        .clone()
+        .unwrap_or(String::from("default"));
+    let api: Api<R> = Api::namespaced(ctx.client.clone(), &ns);
+
+    api.patch(
+        &res.name_any(),
+        &PatchParams::apply("addon-provider-fleet"),
+        &Patch::Apply(res.clone()),
+    )
+    .await
+    .map_err(PatchError::Patch)?;
+
+    info!("Updated fleet object");
+    ctx.diagnostics
+        .read()
+        .await
+        .recorder(ctx.client.clone(), &res)
+        // Record object creation
+        .publish(Event {
+            type_: EventType::Normal,
+            reason: "Updated".into(),
+            note: Some(format!(
+                "Updated fleet object `{}` in `{}`",
+                res.name_any(),
+                res.namespace().unwrap_or_default()
+            )),
+            action: "Creating".into(),
+            secondary: None,
+        })
+        .await
+        .map_err(PatchError::Event)?;
 
     Ok(Action::await_change())
 }

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -2,14 +2,32 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum SyncError {
-    #[error("Cluster sync error: {0}")]
-    ClusterSync(#[source] GetOrCreateError),
+    #[error("{0}")]
+    ClusterSync(#[from] ClusterSyncError),
 
-    #[error("Cluster group sync error: {0}")]
-    GroupSync(#[source] GetOrCreateError),
+    #[error("{0}")]
+    GroupSync(#[from] GroupSyncError),
 
     #[error("Return early")]
     EarlyReturn,
+}
+
+#[derive(Error, Debug)]
+pub enum ClusterSyncError {
+    #[error("Cluster create error: {0}")]
+    GetOrCreateError(#[from] GetOrCreateError),
+
+    #[error("Cluster update error: {0}")]
+    PatchError(#[from] PatchError),
+}
+
+#[derive(Error, Debug)]
+pub enum GroupSyncError {
+    #[error("Cluster group create error: {0}")]
+    GetOrCreateError(#[from] GetOrCreateError),
+
+    #[error("Cluster group update error: {0}")]
+    PatchError(#[from] PatchError),
 }
 
 #[derive(Error, Debug)]
@@ -19,6 +37,15 @@ pub enum GetOrCreateError {
 
     #[error("Create error: {0}")]
     Create(#[source] kube::Error),
+
+    #[error("Diagnostics error: {0}")]
+    Event(#[from] kube::Error),
+}
+
+#[derive(Error, Debug)]
+pub enum PatchError {
+    #[error("Patch error: {0}")]
+    Patch(#[source] kube::Error),
 
     #[error("Diagnostics error: {0}")]
     Event(#[from] kube::Error),


### PR DESCRIPTION
Adding two new options for controller users.
1. Patching resources - maintain the state of the Fleet objects as controller defines them
2. Disable owner references - in case the Fleet object is created by some other mechanism (i.e. Rancher), stop managing deletion.