### PR TITLE
Use LOCAL_IP to connect to docker cluster in e2e tests

### DIFF
--- a/testdata/kind-config.yaml
+++ b/testdata/kind-config.yaml
@@ -6,3 +6,5 @@ nodes:
   extraMounts:
     - hostPath: /var/run/docker.sock
       containerPath: /var/run/docker.sock
+networking:
+  apiServerAddress: "$LOCAL_IP"


### PR DESCRIPTION
This would ensure that the clusters are fully imported and ready and able to deploy bundles.