### PR TITLE
docs: add book structure and basic documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,20 @@
-# Cluster API Add-on Provider for Fleet
+# Documentation Index
 
-> NOTE: this is a work in progress. The project is looking for more contributors.
+## Quick start
+Before starting your journey with CAAPF, you may want to familiarize with CAPI and the concept of providers.
+- [Cluster API Quick Start](https://cluster-api.sigs.k8s.io/user/quick-start.html)
+Deploy your own CAPI management cluster and install the Add-on Provider for Fleet.
+- [Getting started with CAAPF](./book/src/topics/index.md)
+
+## Features
+- [Roadmap](./book/src/roadmap.md)
+
+## Development
+If you are a developer, the project provides a series of commands that you can use to configure your local environment and operate with the provider.
+- [Development Guide](./book/src/developers/development.md)
+- [Releasing](./book/src/developers/release.md)
+
+> Remember that this is a work in progress and the project is looking for more contributors.
 
 ## What is Cluster API Add-on Provider for Fleet (CAAPF)?
 
@@ -17,7 +31,7 @@ It provides the following functionality:
 
 ## Getting started
 
-You can refer to the provider documentation [here](./docs/book/src/.).
+You can refer to the rest of the provider documentation [here](./docs/book/src/.).
 
 ## Get in contact
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,0 +1,12 @@
+# Summary
+
+[Introduction](./introduction.md)
+- [CAPI Introduction](./getting-started.md)
+- [Getting Started](./introduction.md)
+- [Topics](./topics/index.md)
+    - [Prerequisites](./topics/prerequisites.md)
+- [Developer Guide](./developers/index.md)
+    - [Development](./developers/development.md)
+    - [Releasing](./developers/releasing.md)
+- [Roadmap](./roadmap.md)
+

--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -1,0 +1,21 @@
+# Development
+
+## Development setup
+
+### Prerequisites
+
+- [kind](https://kind.sigs.k8s.io/)
+- [helm](https://helm.sh/)
+- [just](https://github.com/casey/just)
+
+### Create a local development environment
+
+1. Clone the [CAAPF](https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/) repository locally.
+2. The project provides an easy way of starting your own development environment. You can take some time to study the [justfile](../../../../justfile) that includes a number of pre-configured commands to set up and build your own CAPI management cluster and install the addon provider for Fleet.
+3. Run the following:
+```
+just start-dev
+```
+This command will create a kind cluster and manage the installation of the fleet provider and all dependencies.
+4. Once the installation is complete, you can inspect the current state of your development cluster.
+

--- a/docs/book/src/developers/release.md
+++ b/docs/book/src/developers/release.md
@@ -1,0 +1,1 @@
+# Release

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -1,0 +1,1 @@
+{{#embed-github repo:"kubernetes-sigs/cluster-api" path:"docs/book/src/user/quick-start.md"}}

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -1,0 +1,1 @@
+{{#include ../../../README.md}}

--- a/docs/book/src/roadmap.md
+++ b/docs/book/src/roadmap.md
@@ -1,0 +1,1 @@
+# Roadmap

--- a/docs/book/src/topics/index.md
+++ b/docs/book/src/topics/index.md
@@ -1,0 +1,1 @@
+This section contains information about the main CAAPF features and how to use them.

--- a/docs/book/src/topics/prerequisites.md
+++ b/docs/book/src/topics/prerequisites.md
@@ -1,0 +1,53 @@
+# Prerequisites
+
+## Requirements
+
+- [helm](https://helm.sh/)
+- [CAPI management cluster](https://cluster-api.sigs.k8s.io/).
+    - Features `EXP_CLUSTER_RESOURCE_SET` and `CLUSTER_TOPOLOGY` must be enabled.
+    - It is recommend to use `KUBE_VERSION` >= 1.26.3.
+    - [clusterctl](https://cluster-api.sigs.k8s.io/user/quick-start.html?highlight=clusterctl#install-clusterctl).
+
+## Installation
+
+As this project is still in experimental mode, we recommend you start by installing the provider into a kind development cluster specific for this purpose, so you can interact with it in a safe test environment. **CAUTION: while features of this project are marked as experimental, you could experience unexpected failures**.
+
+### Create your local cluster
+
+> NOTE: if you prefer to opt for a one-command installation, you can refer to the notes on how to use `just` and the project's `justfile` [here](../developers/development.md).
+
+1. Start by adding the helm repositories that are required to proceed with the installation.
+```
+helm repo add fleet https://rancher.github.io/fleet-helm-charts/
+helm repo update
+```
+2. Navigate to [kind-config.yaml](../../../../testdata/kind-config.yaml) and inspect the kind cluster configuration file, that includes a `LOCAL_IP` environment variable that we'll be setting next, based on your local networking configuration.
+```
+export LOCAL_IP=$(ip -4 -j route list default | jq -r .[0].prefsrc)
+envsubst < testdata/kind-config.yaml > _out/kind-config.yaml
+```
+3. Create the local cluster. It is recommended to use `KUBE_VERSION>=1.26.3`.
+```
+kind create cluster --config --image=kindest/node:v{{KUBE_VERSION}} --config _out/kind-config.yaml
+```
+4. Install [fleet](https://github.com/rancher/fleet) and specify the `API_SERVER_URL` and CA.
+```
+# We start by retrieving the CA data from the cluster
+kubectl config view -o json --raw | jq -r '.clusters[] | select(.name=="kind-dev").cluster["certificate-authority-data"]' | base64 -d > _out/ca.pem
+# Set the API server URL
+API_SERVER_URL=`kubectl config view -o json --raw | jq -r '.clusters[] | select(.name=="kind-dev").cluster["server"]'`
+# And proceed with the installation via helm
+helm -n cattle-fleet-system install --create-namespace --wait fleet-crd fleet/fleet-crd
+helm install --create-namespace -n cattle-fleet-system --set apiServerURL=$API_SERVER_URL --set-file apiServerCA=_out/ca.pem fleet fleet/fleet --wait
+```
+5. Install CAPI with the required experimental features enabled and initialized the Docker provider for testing.
+```
+EXP_CLUSTER_RESOURCE_SET=true CLUSTER_TOPOLOGY=true clusterctl init -i docker
+```
+
+Wait for all pods to become ready and your cluster should be ready to use CAAPF!
+
+**Remember that you can follow along with the video demo to install the provider and get started quickly.**
+
+[![asciicast](https://asciinema.org/a/659626.svg)](https://asciinema.org/a/659626)
+


### PR DESCRIPTION
# Description

This PR adds basic documentation on how to install the provider. The docs are structured to support the creation of a book in line with most upstream CAPI projects (for example [CAPG](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/tree/main/docs)).

The documentation is a work in progress and this PR is only a basic scaffolding to build a more complete reference on top of it.