### PR TITLE
Allow name override for generated Fleet cluster

### DIFF
--- a/config/crds/fleet-addon-config.yaml
+++ b/config/crds/fleet-addon-config.yaml
@@ -25,6 +25,10 @@ spec:
                 description: Cluster controller settings
                 nullable: true
                 properties:
+                  agent_namespace:
+                    description: Namespace selection for the fleet agent
+                    nullable: true
+                    type: string
                   enabled:
                     description: |-
                       Enable Cluster config funtionality.
@@ -33,7 +37,7 @@ spec:
                     nullable: true
                     type: boolean
                   naming:
-                    description: Specifies a name suffix for the fleet cluster
+                    description: Naming settings for the fleet cluster
                     properties:
                       prefix:
                         description: Specify a prefix for the Cluster name, applied to created Fleet cluster

--- a/src/api/fleet_addon_config.rs
+++ b/src/api/fleet_addon_config.rs
@@ -63,8 +63,11 @@ pub struct ClusterConfig {
     /// Setting to disable setting owner references on the created resources
     pub set_owner_references: Option<bool>,
 
-    /// Specifies a name suffix for the fleet cluster
+    /// Naming settings for the fleet cluster
     pub naming: NamingStrategy,
+
+    /// Namespace selection for the fleet agent
+    pub agent_namespace: Option<String>,
 
     #[cfg(feature = "agent-initiated")]
     /// Prepare initial cluster for agent initiated connection
@@ -85,6 +88,7 @@ impl Default for ClusterConfig {
         Self {
             set_owner_references: Some(true),
             naming: Default::default(),
+            agent_namespace: "fleet-addon-agent".to_string().into(),
             enabled: Some(true),
             #[cfg(feature = "agent-initiated")]
             agent_initiated: Some(true),

--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -65,16 +65,19 @@ impl Cluster {
             spec: match config.agent_initiated {
                 Some(true) => fleet_cluster::ClusterSpec {
                     client_id: Some(Alphanumeric.sample_string(&mut rand::thread_rng(), 64)),
+                    agent_namespace: config.agent_namespace,
                     ..Default::default()
                 },
                 None | Some(false) => fleet_cluster::ClusterSpec {
                     kube_config_secret: Some(format!("{}-kubeconfig", self.name_any())),
+                    agent_namespace: config.agent_namespace,
                     ..Default::default()
                 },
             },
             #[cfg(not(feature = "agent-initiated"))]
             spec: fleet_cluster::ClusterSpec {
                 kube_config_secret: Some(format!("{}-kubeconfig", self.name_any())),
+                agent_namespace: config.agent_namespace,
                 ..Default::default()
             },
             status: Default::default(),


### PR DESCRIPTION
- In case a cluster needs to have a different name, the config will have an option.
- Established a namespace convention for the fleet agent - "fleet-addon-agent"