### PR TITLE
Label selector based import setting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Test
         run: just test-unit
-  test-e2e:
+  test-e2e-cluster-class:
     runs-on: ubuntu-latest
     steps:
       - name: Install just
@@ -42,5 +42,26 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: artifacts
+          name: artifacts-cluster-class-import
+          path: _out/gather
+  test-e2e-import:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install just
+        uses: extractions/setup-just@v2
+      - name: Install kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+      - uses: actions/checkout@v4
+      - name: Test
+        run: just test-import
+      - name: Collect artifacts
+        if: always()
+        run: just collect-test-import
+      - name: Store run artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: artifacts-import
           path: _out/gather

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -21,17 +21,17 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.6.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d223b13fd481fc0d1f83bb12659ae774d9e3601814c68a0bc539731698cca743"
+checksum = "3ae682f693a9cd7b058f2b0b5d9a6d7728a8555779bedbbc35dd88528611d020"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
  "ahash",
- "base64 0.21.7",
- "bitflags 2.5.0",
+ "base64 0.22.1",
+ "bitflags 2.6.0",
  "brotli",
  "bytes",
  "bytestring",
@@ -65,27 +65,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "actix-router"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22475596539443685426b6bdadb926ad0ecaefdfc5fb05e5e3441f15463c511"
+checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
+ "cfg-if",
  "http 0.2.12",
  "regex",
+ "regex-lite",
  "serde",
  "tracing",
 ]
 
 [[package]]
 name = "actix-rt"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f32d40287d3f402ae0028a9d54bef51af15c8769492826a69d28f81893151d"
+checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
 dependencies = [
  "futures-core",
  "tokio",
@@ -93,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb13e7eef0423ea6eab0e59f6c72e7cb46d33691ad56a726b3cd07ddec2c2d4"
+checksum = "b02303ce8d4e8be5b855af6cf3c3a08f3eff26880faad82bab679c22d3650cb5"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -131,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.5.1"
+version = "4.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a6556ddebb638c2358714d853257ed226ece6023ef9364f23f0c70737ea984"
+checksum = "1988c02af8d2b718c05bc4aeb6a66395b7cdf32858c2c71131e5637a8c05a9ff"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -160,6 +162,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "regex",
+ "regex-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -171,21 +174,21 @@ dependencies = [
 
 [[package]]
 name = "actix-web-codegen"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1f50ebbb30eca122b188319a4398b3f7bb4a8cdf50ecfb73bfc6a3c3ce54f5"
+checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
 dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -235,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -301,25 +304,25 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.79"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum"
@@ -334,7 +337,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.30",
  "itoa",
  "matchit",
  "memchr",
@@ -379,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -400,9 +403,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -412,9 +415,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -427,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.5.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -438,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -454,9 +457,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "bytestring"
@@ -469,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.92"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
 dependencies = [
  "jobserver",
  "libc",
@@ -495,7 +498,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -508,7 +511,7 @@ dependencies = [
  "chrono",
  "futures",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "k8s-openapi",
  "kube",
  "opentelemetry 0.20.0",
@@ -581,27 +584,27 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -615,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -625,27 +628,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -670,15 +673,15 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -699,9 +702,9 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
@@ -741,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -829,7 +832,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -874,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -885,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "h2"
@@ -916,9 +919,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -998,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -1015,15 +1018,15 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -1033,9 +1036,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1057,15 +1060,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1084,7 +1087,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
@@ -1102,7 +1105,7 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
  "log",
  "rustls",
@@ -1119,7 +1122,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 0.14.30",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1131,7 +1134,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1140,16 +1143,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
- "hyper 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1214,23 +1217,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -1243,9 +1246,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -1303,7 +1306,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19501afb943ae5806548bc3ebd7f3374153ca057a38f480ef30adfde5ef09755"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "chrono",
  "schemars",
  "serde",
@@ -1313,9 +1316,8 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.92.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231c5a5392d9e2a9b0d923199760d3f1dd73b95288f2871d16c7c90ba4954506"
+version = "0.92.0"
+source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#5ab3b6fa668d514a2337407161d7ced5cfc2002b"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1326,20 +1328,19 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.92.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4bf54135062ff60e2a0dfb3e7a9c8e931fc4a535b4d6bd561e0a1371321c61"
+version = "0.92.0"
+source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#5ab3b6fa668d514a2337407161d7ced5cfc2002b"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "either",
  "futures",
  "home",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-http-proxy",
  "hyper-rustls",
  "hyper-timeout 0.5.1",
@@ -1364,9 +1365,8 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.92.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fb9bd8141cbc0fe6b0d9112d371679b4cb607b45c31dd68d92e40864a12975"
+version = "0.92.0"
+source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#5ab3b6fa668d514a2337407161d7ced5cfc2002b"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1381,22 +1381,20 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.92.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08fc86f70076921fdf2f433bbd2a796dc08ac537dc1db1f062cfa63ed4fa15fb"
+version = "0.92.0"
+source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#5ab3b6fa668d514a2337407161d7ced5cfc2002b"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "kube-runtime"
-version = "0.92.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7eb2fb986f81770eb55ec7f857e197019b31b38768d2410f6c1046ffac34225"
+version = "0.92.0"
+source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#5ab3b6fa668d514a2337407161d7ced5cfc2002b"
 dependencies = [
  "ahash",
  "async-broadcast",
@@ -1405,7 +1403,7 @@ dependencies = [
  "backoff",
  "derivative",
  "futures",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "json-patch",
  "jsonptr",
  "k8s-openapi",
@@ -1428,15 +1426,15 @@ checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "local-channel"
@@ -1457,9 +1455,9 @@ checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1467,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matchers"
@@ -1488,9 +1486,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -1500,9 +1498,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -1537,9 +1535,9 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -1556,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -1680,7 +1678,7 @@ dependencies = [
  "lazy_static",
  "once_cell",
  "opentelemetry 0.23.0",
- "ordered-float 4.2.0",
+ "ordered-float 4.2.1",
  "percent-encoding",
  "rand",
  "thiserror",
@@ -1706,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
 dependencies = [
  "num-traits",
 ]
@@ -1727,9 +1725,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1737,22 +1735,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -1760,7 +1758,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -1772,9 +1770,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.9"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1783,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.9"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1793,22 +1791,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.9"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.9"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
 dependencies = [
  "once_cell",
  "pest",
@@ -1832,7 +1830,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1867,9 +1865,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1909,7 +1907,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1959,23 +1957,23 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1989,14 +1987,20 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
@@ -2006,9 +2010,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "ring"
@@ -2027,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -2042,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.9"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a218f0f6d05669de4eabfb24f31ce802035c952429d037507b4a4a39f0e60c5b"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
  "log",
  "once_cell",
@@ -2057,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -2074,7 +2078,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
@@ -2086,9 +2090,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2097,15 +2101,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "schannel"
@@ -2138,7 +2142,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2159,11 +2163,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2172,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2182,15 +2186,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -2207,13 +2211,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2224,14 +2228,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -2296,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -2320,9 +2324,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2336,15 +2340,15 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2359,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2376,22 +2380,22 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "thiserror"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2406,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef89ece63debf11bc32d1ed8d078ac870cbeb44da02afb02a9ff135ae7ca0582"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -2437,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2452,9 +2456,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2487,7 +2491,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2527,9 +2531,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2537,7 +2541,6 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2554,7 +2557,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.30",
  "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
@@ -2594,10 +2597,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -2652,7 +2655,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2785,9 +2788,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2848,7 +2851,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
  "wasm-bindgen-shared",
 ]
 
@@ -2870,7 +2873,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2909,7 +2912,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2927,7 +2930,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2947,17 +2950,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2968,9 +2972,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2980,9 +2984,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2992,9 +2996,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3004,9 +3014,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3016,9 +3026,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3028,9 +3038,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3040,59 +3050,59 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.12+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "kube"
 version = "0.92.0"
-source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#5ab3b6fa668d514a2337407161d7ced5cfc2002b"
+source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#72660490b2ce04e975d184a01b98ce51e9d7fe6f"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1329,7 +1329,7 @@ dependencies = [
 [[package]]
 name = "kube-client"
 version = "0.92.0"
-source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#5ab3b6fa668d514a2337407161d7ced5cfc2002b"
+source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#72660490b2ce04e975d184a01b98ce51e9d7fe6f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1366,7 +1366,7 @@ dependencies = [
 [[package]]
 name = "kube-core"
 version = "0.92.0"
-source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#5ab3b6fa668d514a2337407161d7ced5cfc2002b"
+source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#72660490b2ce04e975d184a01b98ce51e9d7fe6f"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1382,7 +1382,7 @@ dependencies = [
 [[package]]
 name = "kube-derive"
 version = "0.92.0"
-source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#5ab3b6fa668d514a2337407161d7ced5cfc2002b"
+source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#72660490b2ce04e975d184a01b98ce51e9d7fe6f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1394,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "kube-runtime"
 version = "0.92.0"
-source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#5ab3b6fa668d514a2337407161d7ced5cfc2002b"
+source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#72660490b2ce04e975d184a01b98ce51e9d7fe6f"
 dependencies = [
  "ahash",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -181,7 +181,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -315,7 +315,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 dependencies = [
  "jobserver",
  "libc",
@@ -637,7 +637,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -648,7 +648,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -681,7 +681,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -832,7 +832,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1317,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "kube"
 version = "0.92.0"
-source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#72660490b2ce04e975d184a01b98ce51e9d7fe6f"
+source = "git+https://github.com/kube-rs/kube.git#8329782366039d73e0ba177af84f3da7853ba053"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1329,7 +1329,7 @@ dependencies = [
 [[package]]
 name = "kube-client"
 version = "0.92.0"
-source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#72660490b2ce04e975d184a01b98ce51e9d7fe6f"
+source = "git+https://github.com/kube-rs/kube.git#8329782366039d73e0ba177af84f3da7853ba053"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1366,7 +1366,7 @@ dependencies = [
 [[package]]
 name = "kube-core"
 version = "0.92.0"
-source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#72660490b2ce04e975d184a01b98ce51e9d7fe6f"
+source = "git+https://github.com/kube-rs/kube.git#8329782366039d73e0ba177af84f3da7853ba053"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1382,19 +1382,19 @@ dependencies = [
 [[package]]
 name = "kube-derive"
 version = "0.92.0"
-source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#72660490b2ce04e975d184a01b98ce51e9d7fe6f"
+source = "git+https://github.com/kube-rs/kube.git#8329782366039d73e0ba177af84f3da7853ba053"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "kube-runtime"
 version = "0.92.0"
-source = "git+https://github.com/Danil-Grigorev/kube.git?branch=label-selector-support#72660490b2ce04e975d184a01b98ce51e9d7fe6f"
+source = "git+https://github.com/kube-rs/kube.git#8329782366039d73e0ba177af84f3da7853ba053"
 dependencies = [
  "ahash",
  "async-broadcast",
@@ -1799,7 +1799,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1830,7 +1830,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1907,7 +1907,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2142,7 +2142,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2217,7 +2217,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2228,7 +2228,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2363,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2395,7 +2395,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2491,7 +2491,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2655,7 +2655,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2851,7 +2851,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -2873,7 +2873,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3071,7 +3071,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ actix-web = "4.4.0"
 futures = "0.3.28"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 k8s-openapi = { version = "0.22", features = ["latest", "schemars"] }
-kube = { version = "0.92", features = ["runtime", "client", "derive"]}
+kube = { git = "https://github.com/Danil-Grigorev/kube.git", branch="label-selector-support", features = ["runtime", "client", "derive"]}
 schemars = { version = "0.8.21", features = ["chrono"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ actix-web = "4.4.0"
 futures = "0.3.28"
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 k8s-openapi = { version = "0.22", features = ["latest", "schemars"] }
-kube = { git = "https://github.com/Danil-Grigorev/kube.git", branch="label-selector-support", features = ["runtime", "client", "derive"]}
+kube = { git = "https://github.com/kube-rs/kube.git", features = ["runtime", "client", "derive"]}
 schemars = { version = "0.8.21", features = ["chrono"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"

--- a/config/crds/fleet-addon-config.yaml
+++ b/config/crds/fleet-addon-config.yaml
@@ -22,22 +22,49 @@ spec:
             description: This provides a config for fleet addon functionality
             properties:
               cluster:
-                description: Cluster controller settings
+                description: |-
+                  Enable Cluster config funtionality.
+
+                  This will create Fleet Cluster for each Cluster with the same name. In case the cluster specifies topology.class, the name of the ClusterClass will be added to the Fleet Cluster labels.
                 nullable: true
                 properties:
-                  agent_namespace:
+                  agentNamespace:
                     description: Namespace selection for the fleet agent
                     nullable: true
                     type: string
-                  enabled:
-                    description: |-
-                      Enable Cluster config funtionality.
-
-                      This will create Fleet Cluster for each Cluster with the same name. In case the cluster specifies topology.class, the name of the ClusterClass will be added to the Fleet Cluster labels.
-                    nullable: true
-                    type: boolean
+                  namespaceSelector:
+                    description: 'Namespace label selector. If set, only clusters in the namespace matching label selector will be imported. WARN: this field controls the state of opened watches to the cluster. If changed, requires controller to be reloaded.'
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
                   naming:
                     description: Naming settings for the fleet cluster
+                    nullable: true
                     properties:
                       prefix:
                         description: Specify a prefix for the Cluster name, applied to created Fleet cluster
@@ -48,100 +75,63 @@ spec:
                         nullable: true
                         type: string
                     type: object
-                  set_owner_references:
+                  patchResource:
+                    description: Allow to patch resources, maintaining the desired state. If is not set, resources will only be re-created in case of removal.
+                    nullable: true
+                    type: boolean
+                  selector:
+                    description: 'Cluster label selector. If set, only clusters matching label selector will be imported. WARN: this field controls the state of opened watches to the cluster. If changed, requires controller to be reloaded.'
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  setOwnerReferences:
                     description: Setting to disable setting owner references on the created resources
                     nullable: true
                     type: boolean
                 required:
-                - naming
+                - namespaceSelector
+                - selector
                 type: object
-              cluster_class:
-                description: Cluster class controller settings
-                nullable: true
-                properties:
-                  enabled:
-                    description: |-
-                      Enable clusterClass controller functionality.
+              clusterClass:
+                description: |-
+                  Enable clusterClass controller functionality.
 
-                      This will create Fleet ClusterGroups for each ClusterClaster with the same name.
+                  This will create Fleet ClusterGroups for each ClusterClaster with the same name.
+                nullable: true
+                properties:
+                  patchResource:
+                    description: Allow to patch resources, maintaining the desired state. If is not set, resources will only be re-created in case of removal.
                     nullable: true
                     type: boolean
-                  set_owner_references:
+                  setOwnerReferences:
                     description: Setting to disable setting owner references on the created resources
                     nullable: true
                     type: boolean
-                type: object
-              patch_resource:
-                description: Allow to patch resources, maintaining the desired state.
-                nullable: true
-                type: boolean
-              selectors:
-                description: Import label selectors configuration. If not set, import applies on every cluster.
-                nullable: true
-                properties:
-                  cluster:
-                    description: Cluster label selector. If set, only clusters matching label selector will be imported.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                  namespace:
-                    description: Namespace label selector. If set, only clusters in the namespace matching label selector will be imported.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                required:
-                - cluster
-                - namespace
                 type: object
             type: object
         required:

--- a/config/crds/fleet-addon-config.yaml
+++ b/config/crds/fleet-addon-config.yaml
@@ -75,6 +75,74 @@ spec:
                 description: Allow to patch resources, maintaining the desired state.
                 nullable: true
                 type: boolean
+              selectors:
+                description: Import label selectors configuration. If not set, import applies on every cluster.
+                nullable: true
+                properties:
+                  cluster:
+                    description: Cluster label selector. If set, only clusters matching label selector will be imported.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  namespace:
+                    description: Namespace label selector. If set, only clusters in the namespace matching label selector will be imported.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                required:
+                - cluster
+                - namespace
+                type: object
             type: object
         required:
         - spec

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,6 +16,8 @@ rules:
   - namespaces
   verbs:
   - list
+  - get
+  - watch
 - apiGroups:
   - events.k8s.io
   resources:

--- a/justfile
+++ b/justfile
@@ -105,11 +105,13 @@ deploy-crs:
 
 # Deploy child cluster using docker & kubeadm
 deploy-child-cluster:
+    kubectl --context kind-dev apply -f testdata/config.yaml
     kubectl --context kind-dev apply -f testdata/cluster_docker_kcp.yaml
 
 # Deploy child cluster-call based cluster using docker & kubeadm
 deploy-child-cluster-class:
     kind delete cluster --name capi-quickstart || true
+    kubectl --context kind-dev apply -f testdata/config.yaml
     kubectl --context kind-dev apply -f testdata/capi-quickstart.yaml
 
 # Add and update helm repos used
@@ -179,10 +181,10 @@ _test-import-all:
     just deploy-child-cluster-class
     just deploy-crs
     kubectl wait pods --for=condition=Ready --timeout=150s --all --all-namespaces
-    kubectl wait clustergroups.fleet.cattle.io --timeout=150s --for=jsonpath='{.status.clusterCount}=1' quick-start
-    kubectl wait clustergroups.fleet.cattle.io --timeout=150s --for=condition=Ready=true quick-start
-    kubectl wait clusters.fleet.cattle.io --timeout=150s --for=condition=Ready=false capi-quickstart
-    kubectl wait clusters.fleet.cattle.io --timeout=150s --for=condition=Ready=true capi-quickstart
+    kubectl wait clustergroups.fleet.cattle.io --timeout=150s --for=jsonpath='{.status.clusterCount}=1' quick-start -n cluster-class-test
+    kubectl wait clustergroups.fleet.cattle.io --timeout=150s --for=condition=Ready=true quick-start -n cluster-class-test
+    kubectl wait clusters.fleet.cattle.io --timeout=150s --for=condition=Ready=false capi-quickstart -n cluster-class-test
+    kubectl wait clusters.fleet.cattle.io --timeout=150s --for=condition=Ready=true capi-quickstart -n cluster-class-test
 
 # Install kopium
 [private]

--- a/src/api/fleet_addon_config.rs
+++ b/src/api/fleet_addon_config.rs
@@ -3,6 +3,8 @@ use kube::{core::Selector, CustomResource};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+pub const AGENT_NAMESPACE: &str = "fleet-addon-agent";
+
 /// This provides a config for fleet addon functionality
 #[derive(CustomResource, Deserialize, Serialize, Clone, Default, Debug, JsonSchema)]
 #[kube(
@@ -10,15 +12,18 @@ use serde::{Deserialize, Serialize};
     group = "addons.cluster.x-k8s.io",
     version = "v1alpha1"
 )]
+#[serde(rename_all = "camelCase")]
 pub struct FleetAddonConfigSpec {
-    /// Allow to patch resources, maintaining the desired state.
-    pub patch_resource: Option<bool>,
-    /// Import settings for the CAPI cluster. Allows to import clusters based on a set of labels,
-    /// set on the cluster or the namespace.
-    pub selectors: Option<Selectors>,
-    /// Cluster class controller settings
+    /// Enable clusterClass controller functionality.
+    ///
+    /// This will create Fleet ClusterGroups for each ClusterClaster with the same name.
     pub cluster_class: Option<ClusterClassConfig>,
-    /// Cluster controller settings
+
+    /// Enable Cluster config funtionality.
+    ///
+    /// This will create Fleet Cluster for each Cluster with the same name.
+    /// In case the cluster specifies topology.class, the name of the ClusterClass
+    /// will be added to the Fleet Cluster labels.
     pub cluster: Option<ClusterConfig>,
 }
 
@@ -27,9 +32,7 @@ impl Default for FleetAddonConfig {
         Self {
             metadata: Default::default(),
             spec: FleetAddonConfigSpec {
-                patch_resource: Some(true),
                 cluster_class: Some(ClusterClassConfig::default()),
-                selectors: None,
                 cluster: Some(ClusterConfig::default()),
             },
         }
@@ -37,46 +40,70 @@ impl Default for FleetAddonConfig {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ClusterClassConfig {
-    /// Enable clusterClass controller functionality.
-    ///
-    /// This will create Fleet ClusterGroups for each ClusterClaster with the same name.
-    pub enabled: Option<bool>,
-
     /// Setting to disable setting owner references on the created resources
     pub set_owner_references: Option<bool>,
+
+    /// Allow to patch resources, maintaining the desired state.
+    /// If is not set, resources will only be re-created in case of removal.
+    pub patch_resource: Option<bool>,
 }
 
 impl Default for ClusterClassConfig {
     fn default() -> Self {
         Self {
+            patch_resource: Some(true),
             set_owner_references: Some(true),
-            enabled: Some(true),
         }
     }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ClusterConfig {
-    /// Enable Cluster config funtionality.
-    ///
-    /// This will create Fleet Cluster for each Cluster with the same name.
-    /// In case the cluster specifies topology.class, the name of the ClusterClass
-    /// will be added to the Fleet Cluster labels.
-    pub enabled: Option<bool>,
+    /// Allow to patch resources, maintaining the desired state.
+    /// If is not set, resources will only be re-created in case of removal.
+    pub patch_resource: Option<bool>,
 
     /// Setting to disable setting owner references on the created resources
     pub set_owner_references: Option<bool>,
 
     /// Naming settings for the fleet cluster
-    pub naming: NamingStrategy,
+    pub naming: Option<NamingStrategy>,
 
     /// Namespace selection for the fleet agent
     pub agent_namespace: Option<String>,
 
+    /// Import settings for the CAPI cluster. Allows to import clusters based on a set of labels,
+    /// set on the cluster or the namespace.
+    #[serde(flatten)]
+    pub selectors: Selectors,
+
+    // /// Cluster label selector. If set, only clusters matching label selector will be imported.
+    // /// WARN: this field controls the state of opened watches to the cluster. If changed, requires controller to be reloaded.
+    // pub cluster: Option<LabelSelector>,
     #[cfg(feature = "agent-initiated")]
     /// Prepare initial cluster for agent initiated connection
     pub agent_initiated: Option<bool>,
+}
+
+impl ClusterConfig {
+    pub(crate) fn agent_install_namespace(&self) -> String {
+        self.agent_namespace
+            .clone()
+            .unwrap_or(AGENT_NAMESPACE.to_string())
+    }
+
+    #[cfg(feature = "agent-initiated")]
+    pub(crate) fn agent_initiated_connection(&self) -> bool {
+        self.agent_initiated.filter(|&set| set).is_some()
+    }
+
+    pub(crate) fn apply_naming(&self, name: String) -> String {
+        let strategy = self.naming.clone().unwrap_or_default();
+        strategy.apply(name.clone().into()).unwrap_or(name)
+    }
 }
 
 /// NamingStrategy is controlling Fleet cluster naming
@@ -93,10 +120,11 @@ impl Default for ClusterConfig {
         Self {
             set_owner_references: Some(true),
             naming: Default::default(),
-            agent_namespace: "fleet-addon-agent".to_string().into(),
-            enabled: Some(true),
+            agent_namespace: AGENT_NAMESPACE.to_string().into(),
             #[cfg(feature = "agent-initiated")]
             agent_initiated: Some(true),
+            selectors: Default::default(),
+            patch_resource: Some(true),
         }
     }
 }
@@ -116,24 +144,25 @@ impl NamingStrategy {
 
 /// Selectors is controlling Fleet import strategy settings.
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct Selectors {
     /// Namespace label selector. If set, only clusters in the namespace matching label selector will be imported.
     /// WARN: this field controls the state of opened watches to the cluster. If changed, requires controller to be reloaded.
-    pub namespace: LabelSelector,
+    pub namespace_selector: LabelSelector,
 
     /// Cluster label selector. If set, only clusters matching label selector will be imported.
     /// WARN: this field controls the state of opened watches to the cluster. If changed, requires controller to be reloaded.
-    pub cluster: LabelSelector,
+    pub selector: LabelSelector,
 }
 
 impl FleetAddonConfig {
     // Raw cluster selector
     pub(crate) fn cluster_selector(&self) -> Selector {
         self.spec
-            .selectors
-            .clone()
-            .unwrap_or_default()
             .cluster
+            .as_ref()
+            .map(|c| c.selectors.selector.clone())
+            .unwrap_or_default()
             .into()
     }
 
@@ -149,31 +178,52 @@ impl FleetAddonConfig {
     // Raw namespace selector
     pub(crate) fn namespace_selector(&self) -> Selector {
         self.spec
-            .selectors
-            .clone()
+            .cluster
+            .as_ref()
+            .map(|c| c.selectors.namespace_selector.clone())
             .unwrap_or_default()
-            .namespace
             .into()
     }
 
     // Check for general cluster operations, like create, patch, etc. Evaluates to false if disabled.
     pub(crate) fn cluster_operations_enabled(&self) -> bool {
-        self.spec
-            .cluster
-            .iter()
-            .filter_map(|c| c.enabled)
-            .find(|&enabled| enabled)
-            .is_some()
+        self.spec.cluster.is_some()
     }
 
     // Check for general ClusterClass operations, like create, patch, etc. Evaluates to false if disabled.
     pub(crate) fn cluster_class_operations_enabled(&self) -> bool {
+        self.spec.cluster_class.is_some()
+    }
+
+    // Check for general cluster patching setting.
+    pub(crate) fn cluster_patch_enabled(&self) -> bool {
         self.spec
-            .cluster_class
-            .iter()
-            .filter_map(|c| c.enabled)
-            .find(|&enabled| enabled)
+            .cluster
+            .as_ref()
+            .map(|c| c.patch_resource)
+            .unwrap_or_default()
+            .filter(|&enabled| enabled)
             .is_some()
+    }
+
+    // Check for general clusterClass patching setting.
+    pub(crate) fn cluster_class_patch_enabled(&self) -> bool {
+        self.spec
+            .cluster
+            .as_ref()
+            .map(|c| c.patch_resource)
+            .unwrap_or_default()
+            .filter(|&enabled| enabled)
+            .is_some()
+    }
+
+    pub(crate) fn agent_install_namespace(&self) -> String {
+        let default = AGENT_NAMESPACE.to_string();
+        self.spec
+            .cluster
+            .as_ref()
+            .map(|c| c.agent_install_namespace())
+            .unwrap_or(default)
     }
 }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -85,7 +85,11 @@ pub async fn run_cluster_controller(state: State) {
     let clusters = Controller::new(
         clusters,
         Config::default()
-            .labels_from(&config.cluster_watch())
+            .labels_from(
+                &config
+                    .cluster_watch()
+                    .expect("valid cluster label selector"),
+            )
             .any_semantic(),
     )
     .owns(fleet, Config::default().any_semantic())
@@ -98,14 +102,22 @@ pub async fn run_cluster_controller(state: State) {
     )
     .for_each(|_| futures::future::ready(()));
 
-    if config.namespace_selector().selects_all() {
+    if config
+        .namespace_selector()
+        .expect("valid namespace selector")
+        .selects_all()
+    {
         return clusters.await;
     }
 
     let ns_controller = Controller::new(
         Api::<Namespace>::all(client.clone()),
         Config::default()
-            .labels_from(&config.namespace_selector())
+            .labels_from(
+                &config
+                    .namespace_selector()
+                    .expect("valid namespace selector"),
+            )
             .any_semantic(),
     )
     .shutdown_on_signal()

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,13 +1,16 @@
 use crate::api::capi_cluster::Cluster;
 use crate::api::capi_clusterclass::ClusterClass;
+use crate::api::fleet_addon_config::FleetAddonConfig;
 use crate::api::fleet_cluster;
 use crate::api::fleet_clustergroup::ClusterGroup;
 use crate::controllers::controller::{Context, FleetController};
 use crate::metrics::Diagnostics;
 use crate::{Error, Metrics};
 
+use futures::channel::mpsc;
 use futures::StreamExt;
 
+use k8s_openapi::api::core::v1::Namespace;
 use kube::{
     api::Api,
     client::Client,
@@ -16,6 +19,7 @@ use kube::{
         watcher::Config,
     },
 };
+use tokio::sync::Mutex;
 
 use std::sync::Arc;
 use tokio::{sync::RwLock, time::Duration};
@@ -70,17 +74,49 @@ pub async fn run_cluster_controller(state: State) {
     let clusters = Api::<Cluster>::all(client.clone());
     let fleet = Api::<fleet_cluster::Cluster>::all(client.clone());
 
-    Controller::new(clusters, Config::default().any_semantic())
-        .owns(fleet, Config::default().any_semantic())
-        .shutdown_on_signal()
-        .run(
-            Cluster::reconcile,
-            error_policy,
-            state.to_context(client.clone()),
-        )
-        .filter_map(|x| async move { std::result::Result::ok(x) })
-        .for_each(|_| futures::future::ready(()))
-        .await;
+    let config_api: Api<FleetAddonConfig> = Api::all(client.clone());
+    let config = config_api
+        .get_opt("fleet-addon-config")
+        .await
+        .expect("failed to get FleetAddonConfig resource")
+        .unwrap_or_default();
+
+    let (invoke_reconcile, namespace_trigger) = mpsc::channel(0);
+    let clusters = Controller::new(
+        clusters,
+        Config::default()
+            .labels_from(&config.cluster_watch())
+            .any_semantic(),
+    )
+    .owns(fleet, Config::default().any_semantic())
+    .reconcile_all_on(namespace_trigger)
+    .shutdown_on_signal()
+    .run(
+        Cluster::reconcile,
+        error_policy,
+        state.to_context(client.clone()),
+    )
+    .for_each(|_| futures::future::ready(()));
+
+    if config.namespace_selector().selects_all() {
+        return clusters.await;
+    }
+
+    let ns_controller = Controller::new(
+        Api::<Namespace>::all(client.clone()),
+        Config::default()
+            .labels_from(&config.namespace_selector())
+            .any_semantic(),
+    )
+    .shutdown_on_signal()
+    .run(
+        Cluster::reconcile_ns,
+        Cluster::ns_trigger_error_policy,
+        Arc::new(Mutex::new(invoke_reconcile)),
+    )
+    .for_each(|_| futures::future::ready(()));
+
+    tokio::join!(clusters, ns_controller);
 }
 
 /// Initialize the controller and shared state (given the crd is installed)

--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -14,6 +14,7 @@ use kube::api::ObjectMeta;
 
 use kube::core::SelectorExt as _;
 use kube::{api::ResourceExt, runtime::controller::Action, Resource};
+use kube::{Api, Client};
 #[cfg(feature = "agent-initiated")]
 use rand::distributions::{Alphanumeric, DistString as _};
 use tokio::sync::Mutex;
@@ -24,7 +25,7 @@ use std::time::Duration;
 
 use super::cluster_class::CLUSTER_CLASS_LABEL;
 use super::controller::{get_or_create, patch, Context, FleetBundle, FleetController};
-use super::{ClusterSyncError, SyncError};
+use super::{ClusterSyncError, LabelCheckError, SyncError};
 
 pub static CONTROLPLANE_READY_CONDITION: &str = "ControlPlaneReady";
 
@@ -64,29 +65,26 @@ impl Cluster {
                     .set_owner_references
                     .is_some_and(|set| set)
                     .then_some(self.owner_ref(&()).into_iter().collect()),
-                name: config
-                    .naming
-                    .unwrap_or_default()
-                    .apply(self.name_any().into()),
+                name: config.apply_naming(self.name_any()).into(),
                 ..self.into()
             },
             #[cfg(feature = "agent-initiated")]
-            spec: match config.agent_initiated {
-                Some(true) => fleet_cluster::ClusterSpec {
+            spec: match config.agent_initiated_connection() {
+                true => fleet_cluster::ClusterSpec {
                     client_id: Some(Alphanumeric.sample_string(&mut rand::thread_rng(), 64)),
-                    agent_namespace: config.agent_namespace,
+                    agent_namespace: config.agent_install_namespace().into(),
                     ..Default::default()
                 },
-                None | Some(false) => fleet_cluster::ClusterSpec {
+                false => fleet_cluster::ClusterSpec {
                     kube_config_secret: Some(format!("{}-kubeconfig", self.name_any())),
-                    agent_namespace: config.agent_namespace,
+                    agent_namespace: config.agent_install_namespace().into(),
                     ..Default::default()
                 },
             },
             #[cfg(not(feature = "agent-initiated"))]
             spec: fleet_cluster::ClusterSpec {
                 kube_config_secret: Some(format!("{}-kubeconfig", self.name_any())),
-                agent_namespace: config.agent_namespace,
+                agent_namespace: config.agent_install_namespace().into(),
                 ..Default::default()
             },
             status: Default::default(),
@@ -142,9 +140,17 @@ impl FleetBundle for FleetClusterBundle {
 impl FleetController for Cluster {
     type Bundle = FleetClusterBundle;
 
-    fn to_bundle(&self, config: &FleetAddonConfig) -> Result<FleetClusterBundle> {
-        if !self.selector_matches(config.cluster_selector()) || !config.cluster_operations_enabled()
-        {
+    async fn to_bundle(
+        &self,
+        ctx: Arc<Context>,
+        config: &FleetAddonConfig,
+    ) -> Result<FleetClusterBundle> {
+        let matching_labels = self
+            .matching_labels(config, ctx.client.clone())
+            .await
+            .map_err(Into::<SyncError>::into)?;
+
+        if !matching_labels || !config.cluster_operations_enabled() {
             Err(SyncError::EarlyReturn)?;
         }
 
@@ -171,6 +177,20 @@ impl Cluster {
             .find(|&ready| ready);
 
         ready_condition.or(cp_ready).map(|_| self)
+    }
+
+    pub async fn matching_labels(
+        &self,
+        config: &FleetAddonConfig,
+        client: Client,
+    ) -> Result<bool, LabelCheckError> {
+        let matches = config.cluster_selector()?.matches(self.labels()) || {
+            let ns = self.namespace().unwrap_or("default".into());
+            let namespace: Namespace = Api::all(client).get(ns.as_str()).await?;
+            config.namespace_selector()?.matches(namespace.labels())
+        };
+
+        Ok(matches)
     }
 
     pub async fn reconcile_ns(

--- a/src/controllers/cluster_class.rs
+++ b/src/controllers/cluster_class.rs
@@ -73,7 +73,11 @@ impl FleetBundle for FleetClusterClassBundle {
 impl FleetController for ClusterClass {
     type Bundle = FleetClusterClassBundle;
 
-    fn to_bundle(&self, config: &FleetAddonConfig) -> Result<FleetClusterClassBundle> {
+    async fn to_bundle(
+        &self,
+        _ctx: Arc<Context>,
+        config: &FleetAddonConfig,
+    ) -> Result<FleetClusterClassBundle> {
         if !config.cluster_class_operations_enabled() {
             Err(SyncError::EarlyReturn)?;
         }

--- a/src/controllers/cluster_class.rs
+++ b/src/controllers/cluster_class.rs
@@ -74,13 +74,9 @@ impl FleetController for ClusterClass {
     type Bundle = FleetClusterClassBundle;
 
     fn to_bundle(&self, config: &FleetAddonConfig) -> Result<FleetClusterClassBundle> {
-        config
-            .spec
-            .cluster_class
-            .iter()
-            .filter_map(|c| c.enabled)
-            .find(|&enabled| enabled)
-            .ok_or(SyncError::EarlyReturn)?;
+        if !config.cluster_class_operations_enabled() {
+            Err(SyncError::EarlyReturn)?;
+        }
 
         let mut fleet_group: ClusterGroup = self.into();
         if let Some(ClusterClassConfig {

--- a/src/controllers/cluster_class.rs
+++ b/src/controllers/cluster_class.rs
@@ -59,7 +59,7 @@ impl FleetBundle for FleetClusterClassBundle {
             .map_err(Into::<GroupSyncError>::into)
             .map_err(Into::<SyncError>::into)?;
 
-        if let Some(true) = self.config.spec.patch_resource {
+        if self.config.cluster_class_patch_enabled() {
             patch(ctx, self.fleet_group.clone())
                 .await
                 .map_err(Into::<GroupSyncError>::into)

--- a/src/controllers/controller.rs
+++ b/src/controllers/controller.rs
@@ -161,7 +161,9 @@ where
 
         finalizer(&cluster_api, FLEET_FINALIZER, self, |event| async {
             let r = match event {
-                finalizer::Event::Apply(c) => c.to_bundle(&config)?.sync(ctx).await,
+                finalizer::Event::Apply(c) => {
+                    c.to_bundle(ctx.clone(), &config).await?.sync(ctx).await
+                }
                 finalizer::Event::Cleanup(c) => c.cleanup(ctx).await,
             };
 
@@ -193,5 +195,9 @@ where
         Ok(Action::await_change())
     }
 
-    fn to_bundle(&self, config: &FleetAddonConfig) -> crate::Result<Self::Bundle>;
+    async fn to_bundle(
+        &self,
+        ctx: Arc<Context>,
+        config: &FleetAddonConfig,
+    ) -> crate::Result<Self::Bundle>;
 }

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -8,6 +8,9 @@ pub enum SyncError {
     #[error("{0}")]
     GroupSync(#[from] GroupSyncError),
 
+    #[error("{0}")]
+    LabelCheck(#[from] LabelCheckError),
+
     #[error("Cluster registration token create error {0}")]
     ClusterRegistrationTokenSync(#[from] GetOrCreateError),
 
@@ -43,6 +46,15 @@ pub enum GetOrCreateError {
 
     #[error("Diagnostics error: {0}")]
     Event(#[from] kube::Error),
+}
+
+#[derive(Error, Debug)]
+pub enum LabelCheckError {
+    #[error("Namespace lookup error: {0}")]
+    NamespaceLookup(#[from] kube::Error),
+
+    #[error("Parse expression error: {0}")]
+    Expression(#[from] kube::core::ParseExpressionError),
 }
 
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use controllers::SyncError;
+use futures::channel::mpsc::TrySendError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -11,6 +12,9 @@ pub enum Error {
 
     #[error("Fleet error: {0}")]
     FleetError(#[from] SyncError),
+
+    #[error("Namespace trigger error: {0}")]
+    TriggerError(#[from] TrySendError<()>),
 
     #[error("Finalizer Error: {0}")]
     // NB: awkward type because finalizer::Error embeds the reconciler error (which is this)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
-
 use crate::Error;
 use chrono::{DateTime, Utc};
-use kube::{runtime::events::{Recorder, Reporter}, Client, Resource, ResourceExt};
+use kube::{
+    runtime::events::{Recorder, Reporter},
+    Client, Resource, ResourceExt,
+};
 use prometheus::{histogram_opts, opts, HistogramVec, IntCounter, IntCounterVec, Registry};
 use serde::Serialize;
 use tokio::time::Instant;

--- a/testdata/capi-quickstart.yaml
+++ b/testdata/capi-quickstart.yaml
@@ -1,8 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-class-test
+  labels:
+    import: ""
+---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
   name: quick-start
-  namespace: default
+  namespace: cluster-class-test
 spec:
   controlPlane:
     machineInfrastructure:
@@ -234,7 +241,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate
 metadata:
   name: quick-start-cluster
-  namespace: default
+  namespace: cluster-class-test
 spec:
   template:
     spec: {}
@@ -243,7 +250,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: quick-start-control-plane
-  namespace: default
+  namespace: cluster-class-test
 spec:
   template:
     spec:
@@ -264,7 +271,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
   name: quick-start-control-plane
-  namespace: default
+  namespace: cluster-class-test
 spec:
   template:
     spec:
@@ -276,7 +283,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
   name: quick-start-default-worker-machinetemplate
-  namespace: default
+  namespace: cluster-class-test
 spec:
   template:
     spec:
@@ -288,7 +295,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachinePoolTemplate
 metadata:
   name: quick-start-default-worker-machinepooltemplate
-  namespace: default
+  namespace: cluster-class-test
 spec:
   template:
     spec:
@@ -298,7 +305,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
   name: quick-start-default-worker-bootstraptemplate
-  namespace: default
+  namespace: cluster-class-test
 spec:
   template:
     spec:
@@ -309,7 +316,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: capi-quickstart
-  namespace: default
+  namespace: cluster-class-test
   labels:
     cni: kindnet
 spec:

--- a/testdata/cluster_docker_kcp.yaml
+++ b/testdata/cluster_docker_kcp.yaml
@@ -10,6 +10,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
+    import: ""
     cni: kindnet
     env: dev
   name: docker-demo

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -1,0 +1,16 @@
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: FleetAddonConfig
+metadata:
+  name: fleet-addon-config
+spec:
+  clusterClass:
+    patchResource: true
+  cluster:
+    patchResource: true
+    selector:
+      matchLabels:
+        import: ""
+    namespaceSelector:
+      matchLabels:
+        import: ""
+

--- a/testdata/ingress-class.yaml
+++ b/testdata/ingress-class.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+  name: nginx


### PR DESCRIPTION
Fixes: #67

Allows to provide config in a similar format:
```yaml
apiVersion: addons.cluster.x-k8s.io/v1alpha1
kind: FleetAddonConfig
metadata:
  name: fleet-addon-config
spec:
  clusterClass:
    patchResource: true
  cluster:
    patchResource: true
    selector:
      matchLabels:
        import: ""
    namespaceSelector:
      matchLabels:
        import: ""
```

Then the cluster will be imported only if it matches `import` label or the namespace it is in matches `import` label.