### PR TITLE
Perform only patch or create+update, improve error handling

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,9 +1,8 @@
 use crate::api::capi_cluster::Cluster;
 use crate::api::capi_clusterclass::ClusterClass;
-use crate::api::fleet_addon_config::FleetAddonConfig;
 use crate::api::fleet_cluster;
 use crate::api::fleet_clustergroup::ClusterGroup;
-use crate::controllers::controller::{Context, FleetController};
+use crate::controllers::controller::{fetch_config, Context, FleetController};
 use crate::metrics::Diagnostics;
 use crate::{Error, Metrics};
 
@@ -77,12 +76,9 @@ pub async fn run_cluster_controller(state: State) {
         .await
         .expect("failed to create kube Client");
 
-    let config_api: Api<FleetAddonConfig> = Api::all(client.clone());
-    let config = config_api
-        .get_opt("fleet-addon-config")
+    let config = fetch_config(client.clone())
         .await
-        .expect("failed to get FleetAddonConfig resource")
-        .unwrap_or_default();
+        .expect("failed to get FleetAddonConfig resource");
 
     let (reader, writer) = reflector::store();
     let clusters = watcher(

--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -7,7 +7,7 @@ use crate::api::fleet_cluster::{self, ClusterAgentTolerations};
 use crate::api::fleet_cluster_registration_token::{
     ClusterRegistrationToken, ClusterRegistrationTokenSpec,
 };
-use crate::{Error, Result};
+use crate::Error;
 use futures::channel::mpsc::Sender;
 use k8s_openapi::api::core::v1::Namespace;
 use kube::api::ObjectMeta;
@@ -24,8 +24,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::cluster_class::CLUSTER_CLASS_LABEL;
-use super::controller::{get_or_create, patch, Context, FleetBundle, FleetController};
-use super::{ClusterSyncError, LabelCheckError, SyncError};
+use super::controller::{
+    fetch_config, get_or_create, patch, Context, FleetBundle, FleetController,
+};
+use super::{BundleResult, ClusterSyncResult, LabelCheckResult};
 
 pub static CONTROLPLANE_READY_CONDITION: &str = "ControlPlaneReady";
 
@@ -123,28 +125,16 @@ impl Cluster {
 }
 
 impl FleetBundle for FleetClusterBundle {
-    async fn sync(&self, ctx: Arc<Context>) -> Result<Action> {
-        get_or_create(ctx.clone(), self.fleet.clone())
-            .await
-            .map_err(Into::<ClusterSyncError>::into)
-            .map_err(Into::<SyncError>::into)?;
-
-        if self.config.cluster_patch_enabled() {
-            patch(ctx.clone(), self.fleet.clone())
-                .await
-                .map_err(Into::<ClusterSyncError>::into)
-                .map_err(Into::<SyncError>::into)?;
-        }
+    async fn sync(&self, ctx: Arc<Context>) -> ClusterSyncResult<Action> {
+        match self.config.cluster_patch_enabled() {
+            true => patch(ctx.clone(), self.fleet.clone()).await?,
+            false => get_or_create(ctx.clone(), self.fleet.clone()).await?,
+        };
 
         #[cfg(feature = "agent-initiated")]
-        get_or_create(
-            ctx,
-            self.cluster_registration_token
-                .clone()
-                .ok_or(SyncError::EarlyReturn)?,
-        )
-        .await
-        .map_err(Into::<crate::SyncError>::into)?;
+        if let Some(cluster_registration_token) = self.cluster_registration_token.clone() {
+            get_or_create(ctx, cluster_registration_token).await?;
+        }
 
         Ok(Action::await_change())
     }
@@ -153,29 +143,24 @@ impl FleetBundle for FleetClusterBundle {
 impl FleetController for Cluster {
     type Bundle = FleetClusterBundle;
 
-    async fn to_bundle(
-        &self,
-        ctx: Arc<Context>,
-        config: &FleetAddonConfig,
-    ) -> Result<FleetClusterBundle> {
-        let matching_labels = self
-            .matching_labels(config, ctx.client.clone())
-            .await
-            .map_err(Into::<SyncError>::into)?;
-
+    async fn to_bundle(&self, ctx: Arc<Context>) -> BundleResult<Option<FleetClusterBundle>> {
+        let config = fetch_config(ctx.clone().client.clone()).await?;
+        let matching_labels = self.matching_labels(&config, ctx.client.clone()).await?;
         if !matching_labels || !config.cluster_operations_enabled() {
-            Err(SyncError::EarlyReturn)?;
+            return Ok(None);
         }
 
-        self.cluster_ready().ok_or(SyncError::EarlyReturn)?;
+        if self.cluster_ready().is_none() {
+            return Ok(None);
+        }
 
-        Ok(FleetClusterBundle {
+        Ok(Some(FleetClusterBundle {
             fleet: self.to_cluster(config.spec.cluster.clone()),
             #[cfg(feature = "agent-initiated")]
             cluster_registration_token: self
                 .to_cluster_registration_token(config.spec.cluster.clone()),
-            config: config.clone(),
-        })
+            config,
+        }))
     }
 }
 
@@ -183,11 +168,9 @@ impl Cluster {
     pub fn cluster_ready(&self) -> Option<&Self> {
         let status = self.status.clone()?;
         let cp_ready = status.control_plane_ready.filter(|&ready| ready);
-        let ready_condition = status
-            .conditions?
-            .iter()
-            .map(|c| c.type_ == CONTROLPLANE_READY_CONDITION && c.status == "True")
-            .find(|&ready| ready);
+        let ready_condition = status.conditions?.iter().find_map(|c| {
+            (c.type_ == CONTROLPLANE_READY_CONDITION && c.status == "True").then_some(true)
+        });
 
         ready_condition.or(cp_ready).map(|_| self)
     }
@@ -196,7 +179,7 @@ impl Cluster {
         &self,
         config: &FleetAddonConfig,
         client: Client,
-    ) -> Result<bool, LabelCheckError> {
+    ) -> LabelCheckResult<bool> {
         let matches = config.cluster_selector()?.matches(self.labels()) || {
             let ns = self.namespace().unwrap_or("default".into());
             let namespace: Namespace = Api::all(client).get(ns.as_str()).await?;

--- a/src/controllers/cluster_group.rs
+++ b/src/controllers/cluster_group.rs
@@ -1,21 +1,16 @@
-use crate::api::fleet_addon_config::FleetAddonConfig;
 use crate::api::fleet_clustergroup::ClusterGroup;
-use crate::Result;
 
 use kube::runtime::controller::Action;
 
 use std::sync::Arc;
 
 use super::controller::{patch, Context, FleetBundle, FleetController};
-use super::{GroupSyncError, SyncError};
+use super::{BundleResult, GroupSyncResult};
 
 impl FleetBundle for ClusterGroup {
     // Applies finalizer on the existing ClusterGroup object, so the deletion event is not missed
-    async fn sync(&self, ctx: Arc<Context>) -> Result<Action> {
-        patch(ctx.clone(), self.clone())
-            .await
-            .map_err(Into::<GroupSyncError>::into)
-            .map_err(Into::<SyncError>::into)?;
+    async fn sync(&self, ctx: Arc<Context>) -> GroupSyncResult<Action> {
+        patch(ctx.clone(), self.clone()).await?;
 
         Ok(Action::await_change())
     }
@@ -24,11 +19,7 @@ impl FleetBundle for ClusterGroup {
 impl FleetController for ClusterGroup {
     type Bundle = ClusterGroup;
 
-    async fn to_bundle(
-        &self,
-        _ctx: Arc<Context>,
-        _config: &FleetAddonConfig,
-    ) -> Result<Self::Bundle> {
-        Ok(self.clone())
+    async fn to_bundle(&self, _ctx: Arc<Context>) -> BundleResult<Option<Self::Bundle>> {
+        Ok(Some(self.clone()))
     }
 }

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -13,10 +13,9 @@ pub enum SyncError {
 
     #[error("Cluster registration token create error {0}")]
     ClusterRegistrationTokenSync(#[from] GetOrCreateError),
-
-    #[error("Return early")]
-    EarlyReturn,
 }
+
+pub type ClusterSyncResult<T, E = ClusterSyncError> = std::result::Result<T, E>;
 
 #[derive(Error, Debug)]
 pub enum ClusterSyncError {
@@ -27,6 +26,8 @@ pub enum ClusterSyncError {
     PatchError(#[from] PatchError),
 }
 
+pub type GroupSyncResult<T, E = GroupSyncError> = std::result::Result<T, E>;
+
 #[derive(Error, Debug)]
 pub enum GroupSyncError {
     #[error("Cluster group create error: {0}")]
@@ -35,6 +36,8 @@ pub enum GroupSyncError {
     #[error("Cluster group update error: {0}")]
     PatchError(#[from] PatchError),
 }
+
+pub type GetOrCreateResult<T, E = GetOrCreateError> = std::result::Result<T, E>;
 
 #[derive(Error, Debug)]
 pub enum GetOrCreateError {
@@ -48,6 +51,8 @@ pub enum GetOrCreateError {
     Event(#[from] kube::Error),
 }
 
+pub type LabelCheckResult<T, E = LabelCheckError> = std::result::Result<T, E>;
+
 #[derive(Error, Debug)]
 pub enum LabelCheckError {
     #[error("Namespace lookup error: {0}")]
@@ -57,6 +62,8 @@ pub enum LabelCheckError {
     Expression(#[from] kube::core::ParseExpressionError),
 }
 
+pub type PatchResult<T, E = PatchError> = std::result::Result<T, E>;
+
 #[derive(Error, Debug)]
 pub enum PatchError {
     #[error("Patch error: {0}")]
@@ -64,6 +71,25 @@ pub enum PatchError {
 
     #[error("Diagnostics error: {0}")]
     Event(#[from] kube::Error),
+}
+
+pub type BundleResult<T, E = BundleError> = std::result::Result<T, E>;
+
+#[derive(Error, Debug)]
+pub enum BundleError {
+    #[error("Label Check error: {0}")]
+    LabelCheck(#[from] LabelCheckError),
+
+    #[error("{0}")]
+    Config(#[from] ConfigFetchError),
+}
+
+pub type ConfigFetchResult<T> = std::result::Result<T, ConfigFetchError>;
+
+#[derive(Error, Debug)]
+pub enum ConfigFetchError {
+    #[error("Config lookup error: {0}")]
+    Lookup(#[from] kube::Error),
 }
 
 pub mod cluster;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use controllers::SyncError;
+use controllers::{BundleError, SyncError};
 use futures::channel::mpsc::TrySendError;
 use thiserror::Error;
 
@@ -9,6 +9,9 @@ pub enum Error {
 
     #[error("Config fetch error: {0}")]
     ConfigFetch(#[source] kube::Error),
+
+    #[error("Bundle error: {0}")]
+    BundleError(#[from] BundleError),
 
     #[error("Fleet error: {0}")]
     FleetError(#[from] SyncError),


### PR DESCRIPTION
- Refactor error handling to avoid multiple `Into<ErrType` calls
- Perform either SSA patch or create+update, reducing number of requests in total. SSA patch is a superset of the both operations for maintaining the generate state of `Fleet` `Cluster` or `ClusterGroup`.

Fixes: #89 