### PR TITLE
Run dependabot on cargo daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: daily
     labels:
       - "kind/cleanup"
       - "area/dependency"


### PR DESCRIPTION
Increase frequency of dependabot updates to daily, in order to integrate API version changes early.