### PR TITLE
✨ Helmops support, kube-rs bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,8 +615,8 @@ dependencies = [
  "futures",
  "http 1.2.0",
  "hyper",
- "k8s-openapi 0.23.0",
- "kube 0.97.0",
+ "k8s-openapi",
+ "kube",
  "opentelemetry 0.20.0",
  "opentelemetry-otlp",
  "prometheus",
@@ -641,8 +641,8 @@ version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9838500a114353b51dd6a49c2c246709d69467f76f912e6b2a82eb24df572517"
 dependencies = [
- "k8s-openapi 0.24.0",
- "kube 0.98.0",
+ "k8s-openapi",
+ "kube",
  "schemars",
  "serde",
  "serde_json",
@@ -920,12 +920,12 @@ dependencies = [
 
 [[package]]
 name = "fleet-api-rs"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cfd7c6df6a0793295424b3da4d595ea088afdeaed37e20d95d932601513a60"
+checksum = "b2c9a7bc5e3bec65abbb3c5ab3604d920224cf1de0ff09b43b8d224effa22ced"
 dependencies = [
- "k8s-openapi 0.23.0",
- "kube 0.97.0",
+ "k8s-openapi",
+ "kube",
  "schemars",
  "serde",
  "serde_json",
@@ -1190,6 +1190,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows",
 ]
 
 [[package]]
@@ -1622,20 +1633,6 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8847402328d8301354c94d605481f25a6bdc1ed65471fd96af8eca71141b13"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "schemars",
- "serde",
- "serde-value",
- "serde_json",
-]
-
-[[package]]
-name = "k8s-openapi"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c75b990324f09bef15e791606b7b7a296d02fc88a344f6eba9390970a870ad5"
@@ -1650,65 +1647,15 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5fd2596428f922f784ca43907c449f104d69055c811135684474143736c67ae"
-dependencies = [
- "k8s-openapi 0.23.0",
- "kube-client 0.97.0",
- "kube-core 0.97.0",
- "kube-derive 0.97.0",
- "kube-runtime",
-]
-
-[[package]]
-name = "kube"
 version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32053dc495efad4d188c7b33cc7c02ef4a6e43038115348348876efd39a53cba"
 dependencies = [
- "k8s-openapi 0.24.0",
- "kube-client 0.98.0",
- "kube-core 0.98.0",
- "kube-derive 0.98.0",
-]
-
-[[package]]
-name = "kube-client"
-version = "0.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d539b6493d162ae5ab691762be972b6a1c20f6d8ddafaae305c0e2111b589d99"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "chrono",
- "either",
- "futures",
- "home",
- "http 1.2.0",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-http-proxy",
- "hyper-rustls",
- "hyper-timeout",
- "hyper-util",
- "jsonpath-rust",
- "k8s-openapi 0.23.0",
- "kube-core 0.97.0",
- "pem",
- "rustls",
- "rustls-pemfile",
- "secrecy",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror 2.0.11",
- "tokio",
- "tokio-util",
- "tower 0.5.1",
- "tower-http",
- "tracing",
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+ "kube-derive",
+ "kube-runtime",
 ]
 
 [[package]]
@@ -1732,8 +1679,8 @@ dependencies = [
  "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",
- "k8s-openapi 0.24.0",
- "kube-core 0.98.0",
+ "k8s-openapi",
+ "kube-core",
  "pem",
  "rustls",
  "rustls-pemfile",
@@ -1751,24 +1698,6 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a87cc0046cf6b62cbb63ae1fbc366ee8ba29269f575289679473754ff5d7a7"
-dependencies = [
- "chrono",
- "form_urlencoded",
- "http 1.2.0",
- "json-patch",
- "k8s-openapi 0.23.0",
- "schemars",
- "serde",
- "serde-value",
- "serde_json",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "kube-core"
 version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97aa830b288a178a90e784d1b0f1539f2d200d2188c7b4a3146d9dc983d596f3"
@@ -1776,25 +1705,13 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "http 1.2.0",
- "k8s-openapi 0.24.0",
+ "json-patch",
+ "k8s-openapi",
  "schemars",
  "serde",
  "serde-value",
  "serde_json",
  "thiserror 2.0.11",
-]
-
-[[package]]
-name = "kube-derive"
-version = "0.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65576922713e6154a89b5a8d2747adca15725b90fa64fc2b828774bf96d6acd8"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn",
 ]
 
 [[package]]
@@ -1812,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.97.0"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f348cc3e6c9be0ae17f300594bde541b667d10ab8934a119edd61ab5123c43e"
+checksum = "7a41af186a0fe80c71a13a13994abdc3ebff80859ca6a4b8a6079948328c135b"
 dependencies = [
  "ahash",
  "async-broadcast",
@@ -1824,10 +1741,11 @@ dependencies = [
  "educe",
  "futures",
  "hashbrown 0.15.2",
+ "hostname",
  "json-patch",
  "jsonptr",
- "k8s-openapi 0.23.0",
- "kube-client 0.97.0",
+ "k8s-openapi",
+ "kube-client",
  "parking_lot",
  "pin-project",
  "serde",
@@ -3455,6 +3373,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ rand = { version = "0.9", features = ["small_rng"] }
 actix-web = "4.9.0"
 futures = "0.3.28"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
-k8s-openapi = { version = "0.23", features = ["latest", "schemars"] }
-kube = { version = "0.97", features = [
+k8s-openapi = { version = "0.24", features = ["latest", "schemars"] }
+kube = { version = "0.98", features = [
     "runtime",
     "client",
     "derive",
@@ -61,7 +61,7 @@ anyhow = "1.0.95"
 base64 = "0.22.1"
 clap = { version = "4.5.27", features = ["derive"] }
 cluster-api-rs = "1.9.4"
-fleet-api-rs = "0.11.2"
+fleet-api-rs = "0.11.3"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/docs/book/src/topics/prerequisites.md
+++ b/docs/book/src/topics/prerequisites.md
@@ -37,8 +37,8 @@ kubectl config view -o json --raw | jq -r '.clusters[] | select(.name=="kind-dev
 # Set the API server URL
 API_SERVER_URL=`kubectl config view -o json --raw | jq -r '.clusters[] | select(.name=="kind-dev").cluster["server"]'`
 # And proceed with the installation via helm
-helm -n cattle-fleet-system install --version v0.10.1 --create-namespace --wait fleet-crd fleet/fleet-crd
-helm install --create-namespace --version v0.10.1 -n cattle-fleet-system --set apiServerURL=$API_SERVER_URL --set-file apiServerCA=_out/ca.pem fleet fleet/fleet --wait
+helm -n cattle-fleet-system install --version v0.12.0-alpha.3 --create-namespace --wait fleet-crd fleet/fleet-crd
+helm install --create-namespace --version v0.12.0-alpha3 -n cattle-fleet-system --set apiServerURL=$API_SERVER_URL --set-file apiServerCA=_out/ca.pem fleet fleet/fleet --wait
 ```
 5. Install CAPI with the required experimental features enabled and initialized the Docker provider for testing.
 ```

--- a/justfile
+++ b/justfile
@@ -124,7 +124,7 @@ install-fleet: _create-out-dir
 
 # Install cluster api and any providers
 install-capi: _download-clusterctl
-    EXP_CLUSTER_RESOURCE_SET=true CLUSTER_TOPOLOGY=true clusterctl init -i docker
+    EXP_CLUSTER_RESOURCE_SET=true CLUSTER_TOPOLOGY=true clusterctl init -i docker -b rke2 -c rke2 -b kubeadm -c kubeadm
 
 # Deploy will deploy the operator
 deploy features="": _download-kustomize

--- a/justfile
+++ b/justfile
@@ -1,10 +1,10 @@
 NAME := "cluster-api-addon-provider-fleet"
-KUBE_VERSION := env_var_or_default('KUBE_VERSION', '1.30.0')
+KUBE_VERSION := env_var_or_default('KUBE_VERSION', '1.31.0')
 ORG := "ghcr.io/rancher-sandbox"
 TAG := "dev"
 HOME_DIR := env_var('HOME')
 YQ_VERSION := "v4.43.1"
-CLUSTERCTL_VERSION := "v1.8.3"
+CLUSTERCTL_VERSION := "v1.9.4"
 OUT_DIR := "_out"
 KUSTOMIZE_VERSION := "v5.4.1"
 ARCH := if arch() == "aarch64" { "arm64"} else { "amd64" }

--- a/src/api/fleet_cluster.rs
+++ b/src/api/fleet_cluster.rs
@@ -27,8 +27,6 @@ pub struct ClusterSpecProxy {
 
 impl From<ClusterSpec> for ClusterSpecProxy {
     fn from(val: ClusterSpec) -> Self {
-        ClusterSpecProxy{
-            proxy: val,
-        }
+        ClusterSpecProxy { proxy: val }
     }
 }

--- a/src/api/fleet_cluster_registration_token.rs
+++ b/src/api/fleet_cluster_registration_token.rs
@@ -27,8 +27,6 @@ pub struct ClusterRegistrationTokenProxy {
 
 impl Into<ClusterRegistrationTokenProxy> for ClusterRegistrationTokenSpec {
     fn into(self) -> ClusterRegistrationTokenProxy {
-        ClusterRegistrationTokenProxy{
-            proxy: self,
-        }
+        ClusterRegistrationTokenProxy { proxy: self }
     }
 }

--- a/src/controllers/addon_config.rs
+++ b/src/controllers/addon_config.rs
@@ -101,6 +101,7 @@ impl FleetAddonConfig {
                     update_dependency: true,
                     create_namespace: true,
                     bootstrap_local_cluster: false,
+                    experimental_oci_ops: true,
                 },
             )
             .await?;

--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -10,7 +10,7 @@ use cluster_api_rs::capi_cluster::ClusterTopology;
 use fleet_api_rs::fleet_cluster::{ClusterAgentTolerations, ClusterSpec};
 use futures::channel::mpsc::Sender;
 use k8s_openapi::api::core::v1::Namespace;
-use kube::api::{DynamicObject, Object, ObjectMeta};
+use kube::api::{Object, ObjectMeta};
 
 use kube::core::SelectorExt as _;
 use kube::{api::ResourceExt, runtime::controller::Action, Resource};

--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -16,7 +16,7 @@ use kube::core::SelectorExt as _;
 use kube::{api::ResourceExt, runtime::controller::Action, Resource};
 use kube::{Api, Client};
 #[cfg(feature = "agent-initiated")]
-use rand::distributions::{Alphanumeric, DistString as _};
+use rand::distr::{Alphanumeric, SampleString as _};
 use tokio::sync::Mutex;
 use tracing::warn;
 
@@ -80,7 +80,7 @@ impl Cluster {
             #[cfg(feature = "agent-initiated")]
             spec: match config.agent_initiated_connection() {
                 true => ClusterSpec {
-                    client_id: Some(Alphanumeric.sample_string(&mut rand::thread_rng(), 64)),
+                    client_id: Some(Alphanumeric.sample_string(&mut rand::rng(), 64)),
                     agent_namespace: config.agent_install_namespace().into(),
                     host_network: config.host_network,
                     agent_tolerations,

--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -10,13 +10,15 @@ use cluster_api_rs::capi_cluster::ClusterTopology;
 use fleet_api_rs::fleet_cluster::{ClusterAgentTolerations, ClusterSpec};
 use futures::channel::mpsc::Sender;
 use k8s_openapi::api::core::v1::Namespace;
-use kube::api::ObjectMeta;
+use kube::api::{DynamicObject, Object, ObjectMeta};
 
 use kube::core::SelectorExt as _;
 use kube::{api::ResourceExt, runtime::controller::Action, Resource};
 use kube::{Api, Client};
 #[cfg(feature = "agent-initiated")]
 use rand::distr::{Alphanumeric, SampleString as _};
+use serde::Serialize;
+use serde_json::Value;
 use tokio::sync::Mutex;
 use tracing::warn;
 
@@ -32,10 +34,61 @@ use super::{BundleResult, ClusterSyncResult, LabelCheckResult};
 pub static CONTROLPLANE_READY_CONDITION: &str = "ControlPlaneReady";
 
 pub struct FleetClusterBundle {
+    template_sources: TemplateSources,
     fleet: fleet_cluster::Cluster,
     #[cfg(feature = "agent-initiated")]
     cluster_registration_token: Option<ClusterRegistrationToken>,
     config: FleetAddonConfig,
+}
+
+pub struct TemplateSources(Cluster);
+
+#[derive(Serialize)]
+struct TemplateValues {
+    #[serde(rename = "Cluster")]
+    cluster: Cluster,
+    #[serde(rename = "ControlPlane")]
+    control_plane: Object<Value, Value>,
+    #[serde(rename = "InfrastructureCluster")]
+    infrastructure_cluster: Object<Value, Value>,
+}
+
+impl TemplateSources {
+    fn new(cluster: &Cluster) -> Self {
+        TemplateSources(cluster.clone())
+    }
+
+    async fn resolve(&self, client: Client) -> Option<Value> {
+        // We need to remove all dynamic or unnessesary values from these resources
+        let mut cluster = self.0.clone();
+
+        cluster.status = None;
+        cluster.meta_mut().managed_fields = None;
+
+        let mut control_plane: Object<Value, Value> = client
+            .fetch(&self.0.spec.proxy.control_plane_ref.clone()?)
+            .await
+            .ok()?;
+
+        control_plane.status = None;
+        control_plane.meta_mut().managed_fields = None;
+
+        let mut infrastructure_cluster: Object<Value, Value> = client
+            .fetch(&self.0.spec.proxy.infrastructure_ref.clone()?)
+            .await
+            .ok()?;
+
+        infrastructure_cluster.status = None;
+        infrastructure_cluster.meta_mut().managed_fields = None;
+
+        let values = TemplateValues {
+            cluster,
+            control_plane,
+            infrastructure_cluster,
+        };
+
+        serde_json::to_value(values).ok()
+    }
 }
 
 impl From<&Cluster> for ObjectMeta {
@@ -60,12 +113,21 @@ impl Cluster {
             None | Some(ClusterTopology { .. }) => self.labels().clone(),
         };
 
-        let agent_tolerations = Some(vec![ClusterAgentTolerations {
-            effect: Some("NoSchedule".into()),
-            operator: Some("Equal".into()),
-            key: Some("node.kubernetes.io/not-ready".into()),
-            ..Default::default()
-        }]);
+        let agent_tolerations = Some(vec![
+            ClusterAgentTolerations {
+                effect: Some("NoSchedule".into()),
+                operator: Some("Equal".into()),
+                key: Some("node.kubernetes.io/not-ready".into()),
+                ..Default::default()
+            },
+            ClusterAgentTolerations {
+                effect: Some("NoSchedule".into()),
+                operator: Some("Equal".into()),
+                key: Some("node.cloudprovider.kubernetes.io/uninitialized".into()),
+                value: Some("true".into()),
+                ..Default::default()
+            },
+        ]);
 
         fleet_cluster::Cluster {
             metadata: ObjectMeta {
@@ -133,9 +195,16 @@ impl Cluster {
 impl FleetBundle for FleetClusterBundle {
     #[allow(refining_impl_trait)]
     async fn sync(&self, ctx: Arc<Context>) -> ClusterSyncResult<Action> {
+        let mut cluster = self.fleet.clone();
+
+        if let Some(template) = self.template_sources.resolve(ctx.client.clone()).await {
+            let template = serde_json::from_value(template)?;
+            cluster.spec.proxy.template_values = Some(template);
+        }
+
         match self.config.cluster_patch_enabled() {
-            true => patch(ctx.clone(), self.fleet.clone()).await?,
-            false => get_or_create(ctx.clone(), self.fleet.clone()).await?,
+            true => patch(ctx.clone(), cluster).await?,
+            false => get_or_create(ctx.clone(), cluster).await?,
         };
 
         #[cfg(feature = "agent-initiated")]
@@ -162,6 +231,7 @@ impl FleetController for Cluster {
         }
 
         Ok(Some(FleetClusterBundle {
+            template_sources: TemplateSources::new(self),
             fleet: self.to_cluster(config.spec.cluster.clone()),
             #[cfg(feature = "agent-initiated")]
             cluster_registration_token: self

--- a/src/controllers/cluster_class.rs
+++ b/src/controllers/cluster_class.rs
@@ -48,7 +48,8 @@ impl From<&ClusterClass> for ClusterGroup {
                     ),
                     ..Default::default()
                 }),
-            }.into(),
+            }
+            .into(),
             status: Default::default(),
         }
     }

--- a/src/controllers/controller.rs
+++ b/src/controllers/controller.rs
@@ -68,19 +68,22 @@ where
     ctx.diagnostics
         .read()
         .await
-        .recorder(ctx.client.clone(), &res)
+        .recorder(ctx.client.clone())
         // Record object creation
-        .publish(Event {
-            type_: EventType::Normal,
-            reason: "Created".into(),
-            note: Some(format!(
-                "Created fleet object `{}` in `{}`",
-                res.name_any(),
-                res.namespace().unwrap_or_default()
-            )),
-            action: "Creating".into(),
-            secondary: None,
-        })
+        .publish(
+            &Event {
+                type_: EventType::Normal,
+                reason: "Created".into(),
+                note: Some(format!(
+                    "Created fleet object `{}` in `{}`",
+                    res.name_any(),
+                    res.namespace().unwrap_or_default()
+                )),
+                action: "Creating".into(),
+                secondary: None,
+            },
+            &res.object_ref(&()),
+        )
         .await?;
 
     Ok(Action::await_change())
@@ -115,19 +118,22 @@ where
     ctx.diagnostics
         .read()
         .await
-        .recorder(ctx.client.clone(), &res)
+        .recorder(ctx.client.clone())
         // Record object creation
-        .publish(Event {
-            type_: EventType::Normal,
-            reason: "Updated".into(),
-            note: Some(format!(
-                "Updated fleet object `{}` in `{}`",
-                res.name_any(),
-                res.namespace().unwrap_or_default()
-            )),
-            action: "Creating".into(),
-            secondary: None,
-        })
+        .publish(
+            &Event {
+                type_: EventType::Normal,
+                reason: "Updated".into(),
+                note: Some(format!(
+                    "Updated fleet object `{}` in `{}`",
+                    res.name_any(),
+                    res.namespace().unwrap_or_default()
+                )),
+                action: "Creating".into(),
+                secondary: None,
+            },
+            &res.object_ref(&()),
+        )
         .await?;
 
     Ok(Action::await_change())
@@ -182,15 +188,18 @@ where
         ctx.diagnostics
             .read()
             .await
-            .recorder(ctx.client.clone(), self)
+            .recorder(ctx.client.clone())
             // Cleanup is perfomed by owner reference
-            .publish(Event {
-                type_: EventType::Normal,
-                reason: "DeleteRequested".into(),
-                note: Some(format!("Delete `{}`", self.name_any())),
-                action: "Deleting".into(),
-                secondary: None,
-            })
+            .publish(
+                &Event {
+                    type_: EventType::Normal,
+                    reason: "DeleteRequested".into(),
+                    note: Some(format!("Delete `{}`", self.name_any())),
+                    action: "Deleting".into(),
+                    secondary: None,
+                },
+                &self.object_ref(&()),
+            )
             .await?;
 
         Ok(Action::await_change())

--- a/src/controllers/helm/install.rs
+++ b/src/controllers/helm/install.rs
@@ -19,6 +19,7 @@ pub struct FleetChart {
     pub update_dependency: bool,
     pub create_namespace: bool,
     pub bootstrap_local_cluster: bool,
+    pub experimental_oci_ops: bool,
 }
 
 #[derive(Deserialize)]
@@ -106,6 +107,10 @@ impl FleetChart {
         install.args([
             "--set",
             &format!("bootstrap.enabled={}", self.bootstrap_local_cluster),
+            "--set-string",
+            "extraEnv[0].name=EXPERIMENTAL_HELM_OPS",
+            "--set-string",
+            &format!("extraEnv[0].value={}", self.experimental_oci_ops),
         ]);
 
         Ok(install.spawn()?)

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -24,6 +24,9 @@ pub enum ClusterSyncError {
 
     #[error("Cluster update error: {0}")]
     PatchError(#[from] PatchError),
+
+    #[error("Cluster json encoding error: {0}")]
+    ClusterEncodeError(#[from] serde_json::Error),
 }
 
 pub type GroupSyncResult<T, E = GroupSyncError> = std::result::Result<T, E>;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4,7 +4,7 @@ use crate::Error;
 use chrono::{DateTime, Utc};
 use kube::{
     runtime::events::{Recorder, Reporter},
-    Client, Resource, ResourceExt,
+    Client, ResourceExt,
 };
 use prometheus::{histogram_opts, opts, HistogramVec, IntCounter, IntCounterVec, Registry};
 use serde::Serialize;
@@ -89,8 +89,8 @@ impl Default for Diagnostics {
 }
 
 impl Diagnostics {
-    pub fn recorder<R: Resource<DynamicType = ()>>(&self, client: Client, cluster: &R) -> Recorder {
-        Recorder::new(client, self.reporter.clone(), cluster.object_ref(&()))
+    pub fn recorder(&self, client: Client) -> Recorder {
+        Recorder::new(client, self.reporter.clone())
     }
 }
 

--- a/testdata/cluster_docker_kcp.yaml
+++ b/testdata/cluster_docker_kcp.yaml
@@ -76,8 +76,8 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: DockerMachineTemplate
       name: docker-demo-control-plane
-  replicas: 3
-  version: v1.27.3
+  replicas: 1
+  version: v1.31.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -129,4 +129,4 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: DockerMachineTemplate
         name: docker-demo-md-0
-      version: v1.27.3
+      version: v1.31.0

--- a/testdata/cluster_docker_rke2.yaml
+++ b/testdata/cluster_docker_rke2.yaml
@@ -103,7 +103,7 @@ metadata:
   namespace: default
 spec:
   agentConfig:
-    version: v1.27.3+rke2r1
+    version: v1.31.0+rke2r1
   # nodeAnnotations:
   #   richtest: "true"
   infrastructureRef:
@@ -147,7 +147,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: DockerMachineTemplate
         name: worker
-      version: v1.27.3
+      version: v1.31.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -167,7 +167,7 @@ spec:
   template:
     spec:
       agentConfig:
-        version: v1.27.3+rke2r1
+        version: v1.31.0+rke2r1
       #nodeAnnotations:
       #  richtest: "true"
       # postRKE2Commands:

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -20,5 +20,5 @@ spec:
       matchLabels:
         import: ""
   install:
-    followLatest: true
+    version: v0.12.0-alpha.3
 


### PR DESCRIPTION
Implement initial integration with `HelmApp`. Currently is not fully working, due to inability to specify template in a `yaml` format (not as a string with `|` or `|-`, as it does not produce correct value), but may work for simple templates without range values:
```yaml
apiversion: fleet.cattle.io/v1alpha1
kind: HelmApp
metadata:
  name: sample1
spec:
  helm:
    releaseName: projectcalico
    repo: https://docs.tigera.io/calico/charts
    chart: tigera-operator
    values:
      installation:
        cni:
          type: Calico
          ipam:
            type: HostLocal
        calicoNetwork:
          bgp: Disabled
          mtu: 1350
          ipPools: # Works only with |- here, which is unfortunately incorrect
            ${- range $cidr := .ClusterValues.Cluster.spec.clusterNetwork.pods.cidrBlocks }
            - cidr: "${ $cidr }"
              encapsulation: None
              natOutgoing: Enabled
              nodeSelector: all()${- end}
  insecureSkipTLSVerify: true
  targets:
  - clusterName: test1
``` 

Fixes: #32 