### PR TITLE
Fix label propagation on clusterGroup

### DIFF
--- a/src/controllers/cluster_class.rs
+++ b/src/controllers/cluster_class.rs
@@ -8,6 +8,7 @@ use kube::api::{ObjectMeta, PatchParams, TypeMeta};
 
 use kube::{api::ResourceExt, runtime::controller::Action, Resource};
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use super::controller::{
@@ -27,7 +28,7 @@ pub struct FleetClusterClassBundle {
 impl From<&ClusterClass> for ClusterGroup {
     fn from(cluster_class: &ClusterClass) -> Self {
         let labels = {
-            let mut labels = cluster_class.labels().clone();
+            let mut labels = BTreeMap::default();
             labels.insert(CLUSTER_CLASS_LABEL.to_string(), cluster_class.name_any());
             labels.insert(
                 CLUSTER_CLASS_NAMESPACE_LABEL.to_string(),


### PR DESCRIPTION
Previous propagation logic change caused issues when `ClusterClass` was labeled differently from `Cluster`. This can be reproduced when creating `ClusterClass` via `GitRepo` resource, which applies helm managed labels on it. Such group was not matching clusters due to labels difference.

Fixes: https://github.com/rancher/turtles/issues/1113