### PR TITLE
Replace cache wide `requeue all` with dynamic watches setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build
         run: just compile
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -23,8 +24,19 @@ jobs:
       - uses: actions/checkout@v4
       - name: Test
         run: just test-unit
-  test-e2e-cluster-class:
+
+  test-e2e:
+    name: test-e2e ${{ matrix.display_name }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - kube_version: "1.30.0"
+            display_name: "stable"
+          - kube_version: "1.32.0"
+            display_name: "latest"
+    env:
+      KUBE_VERSION: ${{ matrix.kube_version }}
     steps:
       - name: Install just
         uses: extractions/setup-just@v2
@@ -34,7 +46,7 @@ jobs:
           install_only: true
           version: v0.26.0
       - uses: actions/checkout@v4
-      - name: Test
+      - name: Test (Cluster Class) - ${{ matrix.display_name }}
         run: just test-cluster-class-import
       - name: Collect artifacts
         if: always()
@@ -43,10 +55,21 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: artifacts-cluster-class-import
+          name: artifacts-cluster-class-import-${{ matrix.display_name }}
           path: _out/gather
+
   test-e2e-import:
+    name: test-e2e-import ${{ matrix.display_name }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - kube_version: "1.30.0"
+            display_name: "stable"
+          - kube_version: "1.32.0"
+            display_name: "latest"
+    env:
+      KUBE_VERSION: ${{ matrix.kube_version }}
     steps:
       - name: Install just
         uses: extractions/setup-just@v2
@@ -56,7 +79,7 @@ jobs:
           install_only: true
           version: v0.26.0
       - uses: actions/checkout@v4
-      - name: Test
+      - name: Test (Import) - ${{ matrix.display_name }}
         run: just test-import
       - name: Collect artifacts
         if: always()
@@ -65,10 +88,21 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: artifacts-import
+          name: artifacts-import-${{ matrix.display_name }}
           path: _out/gather
+
   test-e2e-import-rke2:
+    name: test-e2e-import-rke2 ${{ matrix.display_name }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - kube_version: "1.30.0"
+            display_name: "stable"
+          - kube_version: "1.32.0"
+            display_name: "latest"
+    env:
+      KUBE_VERSION: ${{ matrix.kube_version }}
     steps:
       - name: Install just
         uses: extractions/setup-just@v2
@@ -78,7 +112,7 @@ jobs:
           install_only: true
           version: v0.26.0
       - uses: actions/checkout@v4
-      - name: Test
+      - name: Test (Import RKE2) - ${{ matrix.display_name }}
         run: just test-import-rke2
       - name: Collect artifacts
         if: always()
@@ -87,5 +121,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: artifacts-import-rke2
+          name: artifacts-import-rke2-${{ matrix.display_name }}
           path: _out/gather

--- a/src/api/fleet_addon_config.rs
+++ b/src/api/fleet_addon_config.rs
@@ -271,16 +271,6 @@ pub struct Selectors {
 }
 
 impl FleetAddonConfig {
-    // Raw cluster selector
-    pub(crate) fn cluster_selector(&self) -> Result<Selector, ParseExpressionError> {
-        self.spec
-            .cluster
-            .as_ref()
-            .map(|c| c.selectors.selector.clone())
-            .unwrap_or_default()
-            .try_into()
-    }
-
     // Provide a static label selector for cluster objects, which can be always be set
     // and will not cause cache events from resources in the labeled Namespace to be missed
     pub(crate) fn cluster_watch(&self) -> Result<Selector, ParseExpressionError> {
@@ -289,6 +279,16 @@ impl FleetAddonConfig {
             .selects_all()
             .then_some(self.cluster_selector()?)
             .unwrap_or_default())
+    }
+
+    // Raw cluster selector
+    pub(crate) fn cluster_selector(&self) -> Result<Selector, ParseExpressionError> {
+        self.spec
+            .cluster
+            .as_ref()
+            .map(|c| c.selectors.selector.clone())
+            .unwrap_or_default()
+            .try_into()
     }
 
     // Raw namespace selector

--- a/src/controllers/controller.rs
+++ b/src/controllers/controller.rs
@@ -47,6 +47,8 @@ pub struct Context {
     pub dispatcher: MultiDispatcher,
     // shared stream of dynamic events
     pub stream: BroadcastStream<DynamicStream>,
+    // k8s minor version
+    pub version: u32,
 }
 
 pub(crate) async fn get_or_create<R>(ctx: Arc<Context>, res: R) -> GetOrCreateResult<Action>


### PR DESCRIPTION
This change simplifies setup for selective watches on cluster and namespace resources by replacing `reconcile_all_on` which is triggered on any namespace change, with a dynamic cluster cache population based on selectors matching `namespace`.

This setup adds watches on individual clusters per each matching `namespace`, as well as clusters matching the cluster selector, ignoring all the rest. Updating selectors leads to cache re-population.

Related to #179 