### PR TITLE
Add conditions and expose Fleet FG through config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ COPY ./ ./
 ARG features=""
 RUN cargo install --locked --target x86_64-unknown-linux-musl --features=${features} --path .
 
-FROM --platform=amd64 registry.suse.com/suse/helm:3.13 AS helm-amd64
-FROM --platform=arm64 registry.suse.com/suse/helm:3.13 AS helm-arm64
+FROM --platform=amd64 registry.suse.com/suse/helm:3.17 AS helm-amd64
+FROM --platform=arm64 registry.suse.com/suse/helm:3.17 AS helm-arm64
 
 FROM helm-amd64 AS target-amd64
 COPY --from=build-amd64 --chmod=0755 /root/.cargo/bin/controller /apps/controller

--- a/config/crds/fleet-addon-config.yaml
+++ b/config/crds/fleet-addon-config.yaml
@@ -263,7 +263,23 @@ spec:
               config:
                 nullable: true
                 properties:
+                  featureGates:
+                    description: feature gates controlling experimental features
+                    nullable: true
+                    properties:
+                      experimentalHelmOps:
+                        description: Enables experimental Helm operations support.
+                        type: boolean
+                      experimentalOciStorage:
+                        description: Enables experimental OCI  storage support.
+                        type: boolean
+                    required:
+                    - experimentalHelmOps
+                    - experimentalOciStorage
+                    type: object
                   server:
+                    description: fleet server url configuration options
+                    nullable: true
                     oneOf:
                     - required:
                       - inferLocal
@@ -305,8 +321,6 @@ spec:
                       inferLocal:
                         type: boolean
                     type: object
-                required:
-                - server
                 type: object
               install:
                 nullable: true
@@ -328,6 +342,39 @@ spec:
           status:
             nullable: true
             properties:
+              conditions:
+                description: conditions represents the observations of a Fleet addon current state.
+                items:
+                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               installedVersion:
                 nullable: true
                 type: string

--- a/docs/src/02_getting_started/02_configuration.md
+++ b/docs/src/02_getting_started/02_configuration.md
@@ -29,7 +29,7 @@ spec:
     server:
       inferLocal: true # Uses default `kuberenetes` endpoint and secret for APIServerURL configuration
   install:
-    version: v0.12.0-beta.1 # We will install alpha for helmapp support
+    version: v0.12.0-rc.1 # We will install alpha for helmapp support
 ```
 
 ### Fleet Public URL and Certificate setup
@@ -52,7 +52,7 @@ spec:
     server:
       inferLocal: true # Uses default `kuberenetes` endpoint and secret for APIServerURL configuration
   install:
-    version: v0.12.0-beta.1 # We will install alpha for helmapp support
+    version: v0.12.0-rc.1 # We will install alpha for helmapp support
 ```
 
 This scenario works well in a test setup, while using CAPI docker provider and docker clusters.
@@ -80,3 +80,24 @@ spec:
 ### Cluster Import Strategy
 
 -> [Import Strategy](../04_reference/01_import-strategy.md)
+
+### Fleet Feature Flags
+
+Fleet includes experimental features that can be enabled or disabled using feature gates in the `FleetAddonConfig` resource. These flags are configured under .spec.config.featureGates.
+
+To enable experimental features such as OCI storage support and `HelmApp` support, update the FleetAddonConfig as follows:
+
+```yaml
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: FleetAddonConfig
+metadata:
+  name: fleet-addon-config
+spec:
+  config:
+    featureGates:
+      experimentalOciStorage: true   # Enables experimental OCI storage support
+      experimentalHelmOps: true      # Enables experimental Helm operations support
+```
+
+**By default, if the `featureGates` field is not present, these feature gates are *enabled*. To disable these need to explicitly be set to `false`.**
+

--- a/docs/src/03_tutorials/01_prerequisites.md
+++ b/docs/src/03_tutorials/01_prerequisites.md
@@ -27,8 +27,8 @@ kubectl config view -o json --raw | jq -r '.clusters[] | select(.name=="kind-dev
 # Set the API server URL
 API_SERVER_URL=`kubectl config view -o json --raw | jq -r '.clusters[] | select(.name=="kind-dev").cluster["server"]'`
 # And proceed with the installation via helm
-helm -n cattle-fleet-system install --version v0.12.0-beta.1 --create-namespace --wait fleet-crd fleet/fleet-crd
-helm install --create-namespace --version v0.12.0-beta.1 -n cattle-fleet-system --set apiServerURL=$API_SERVER_URL --set-file apiServerCA=_out/ca.pem fleet fleet/fleet --wait
+helm -n cattle-fleet-system install --version v0.12.0-rc.1 --create-namespace --wait fleet-crd fleet/fleet-crd
+helm install --create-namespace --version v0.12.0-rc.1 -n cattle-fleet-system --set apiServerURL=$API_SERVER_URL --set-file apiServerCA=_out/ca.pem fleet fleet/fleet --wait
 ```
 4. Install CAPI with the required experimental features enabled and initialized the Docker provider for testing.
 ```

--- a/docs/src/03_tutorials/03_installing_calico.md
+++ b/docs/src/03_tutorials/03_installing_calico.md
@@ -3,7 +3,7 @@
 <div class="warning">
 
 Note: For this setup to work, you need to install Fleet and Fleet CRDs charts via
-`FleetAddonConfig` resource. Both need to have version >= v0.12.0-beta.1,
+`FleetAddonConfig` resource. Both need to have version >= v0.12.0-rc.1,
 which provides support for `HelmApp` resource.
 
 </div>

--- a/docs/src/03_tutorials/04_installing_calico_via_gitrepo.md
+++ b/docs/src/03_tutorials/04_installing_calico_via_gitrepo.md
@@ -3,7 +3,7 @@
 <div class="warning">
 
 Note: For this setup to work, you need have Fleet and Fleet CRDs charts installed
-with version >= `v0.12.0-alpha.14`.
+with version >= `v0.12.0-rc.1`.
 
 </div>
 

--- a/justfile
+++ b/justfile
@@ -154,7 +154,7 @@ deploy features="": _download-kustomize
     just build-and-load
     kustomize build config/default | kubectl apply -f -
     kubectl --context kind-dev apply -f testdata/config.yaml
-    kubectl wait fleetaddonconfigs fleet-addon-config --for=jsonpath='{.status.installedVersion}' --timeout=150s
+    kubectl wait fleetaddonconfigs fleet-addon-config --timeout=150s --for=condition=Ready=true
 
 undeploy: _download-kustomize
     kustomize build config/default | kubectl delete --ignore-not-found=true -f -

--- a/src/controllers/helm/mod.rs
+++ b/src/controllers/helm/mod.rs
@@ -10,6 +10,14 @@ pub enum FleetInstallError {
     FleetInstall(#[from] io::Error),
 }
 
+pub type FleetPatchResult<T> = std::result::Result<T, FleetPatchError>;
+
+#[derive(Error, Debug)]
+pub enum FleetPatchError {
+    #[error("Fleet chart patch error: {0}")]
+    FleetPatch(#[from] io::Error),
+}
+
 pub type FleetCRDInstallResult<T> = std::result::Result<T, FleetCRDInstallError>;
 
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+use std::io;
+
 use controllers::{
-    addon_config::{AddonConfigSyncError, DynamicWatcherError},
-    BundleError, SyncError,
+    addon_config::{AddonConfigSyncError, DynamicWatcherError, FleetPatchError},
+    helm, BundleError, SyncError,
 };
 use futures::channel::mpsc::TrySendError;
 use thiserror::Error;
@@ -21,6 +23,18 @@ pub enum Error {
 
     #[error("Fleet config error: {0}")]
     FleetConfigError(#[from] AddonConfigSyncError),
+
+    #[error("Fleet chart patch error: {0}")]
+    FleetChartPatchError(#[from] FleetPatchError),
+
+    #[error("Fleet repo add error: {0}")]
+    RepoAdd(#[from] helm::RepoAddError),
+
+    #[error("Fleet repo update error: {0}")]
+    RepoUpdate(#[from] helm::RepoUpdateError),
+
+    #[error("Error waiting for commadnd: {0}")]
+    CommandError(#[from] io::Error),
 
     #[error("Dynamic watcher error: {0}")]
     DynamicWatcherError(#[from] DynamicWatcherError),

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -21,5 +21,5 @@ spec:
       matchLabels:
         import: ""
   install:
-    version: v0.12.0-beta.1 # We will install alpha for helmapp support
+    version: v0.12.0-rc.1 # We will install alpha for helmapp support
 


### PR DESCRIPTION
Fleet includes experimental features that can be enabled or disabled using feature gates in the `FleetAddonConfig` resource. These flags are configured under `.spec.config.featureGates`.

To enable experimental features such as OCI storage support and `HelmApp` support, update the FleetAddonConfig as follows:

```yaml
apiVersion: addons.cluster.x-k8s.io/v1alpha1
kind: FleetAddonConfig
metadata:
  name: fleet-addon-config
spec:
  config:
    featureGates:
      experimentalOciStorage: true   # Enables experimental OCI storage support
      experimentalHelmOps: true      # Enables experimental Helm operations support
```

As the controller grows in complexity, now the `FleetAddonConfig` provides conditions, indicating current status of the addon provider at any moment.

Fixes #213 