### PR TITLE
Simplify dynamic watch setup version separation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ telemetry = ["tonic", "opentelemetry-otlp"]
 rand = { version = "0.9", features = ["small_rng"] }
 actix-web = "4.10.2"
 futures = "0.3.28"
-tokio = { version = "1.44.1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.44.1", features = ["macros", "rt-multi-thread", "process"] }
 k8s-openapi = { version = "0.24", features = ["latest", "schemars"] }
 kube = { version = "0.99.0", features = [
     "runtime",

--- a/src/api/fleet_addon_config.rs
+++ b/src/api/fleet_addon_config.rs
@@ -269,6 +269,18 @@ pub enum Install {
     Version(String),
 }
 
+impl Install {
+    /// Perform version normalization for comparison with `helm search` app_version output
+    pub(crate) fn normalized(self) -> Self {
+        match self {
+            Install::FollowLatest(_) => self,
+            Install::Version(version) => {
+                Install::Version(version.strip_prefix("v").unwrap_or(&version).into())
+            }
+        }
+    }
+}
+
 impl Default for Install {
     fn default() -> Self {
         Self::FollowLatest(true)

--- a/src/api/fleet_addon_config.rs
+++ b/src/api/fleet_addon_config.rs
@@ -326,16 +326,6 @@ pub struct Selectors {
 }
 
 impl FleetAddonConfig {
-    // Provide a static label selector for cluster objects, which can be always be set
-    // and will not cause cache events from resources in the labeled Namespace to be missed
-    pub(crate) fn cluster_watch(&self) -> Result<Selector, ParseExpressionError> {
-        Ok(self
-            .namespace_selector()?
-            .selects_all()
-            .then_some(self.cluster_selector()?)
-            .unwrap_or_default())
-    }
-
     // Raw cluster selector
     pub(crate) fn cluster_selector(&self) -> Result<Selector, ParseExpressionError> {
         self.spec

--- a/src/api/fleet_clustergroup.rs
+++ b/src/api/fleet_clustergroup.rs
@@ -6,6 +6,7 @@ use fleet_api_rs::fleet_clustergroup::{
 use k8s_openapi::api::core::v1::ObjectReference;
 use kube::{
     api::{ObjectMeta, TypeMeta},
+    core::{Expression, Selector},
     runtime::reflector::ObjectRef,
     Resource, ResourceExt as _,
 };
@@ -50,6 +51,13 @@ impl ClusterGroup {
                 .within(&namespace)
                 .into(),
         )
+    }
+
+    pub(crate) fn group_selector() -> Selector {
+        Selector::from_iter([
+            Expression::Exists(CLUSTER_CLASS_LABEL.to_string()),
+            Expression::Exists(CLUSTER_CLASS_NAMESPACE_LABEL.to_string()),
+        ])
     }
 }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -20,9 +20,9 @@ use k8s_openapi::api::core::v1::Namespace;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, Time};
 use kube::api::{DynamicObject, Patch, PatchParams};
 use kube::core::DeserializeGuard;
+use kube::runtime::reflector::store::Writer;
 use kube::runtime::reflector::ObjectRef;
 use kube::runtime::{metadata_watcher, predicates, reflector, watcher, WatchStreamExt};
-use kube::ResourceExt;
 use kube::{
     api::Api,
     client::Client,
@@ -31,6 +31,7 @@ use kube::{
         watcher::Config,
     },
 };
+use kube::{Resource, ResourceExt};
 use tokio::sync::Mutex;
 
 use std::collections::BTreeMap;
@@ -111,6 +112,28 @@ impl State {
     }
 }
 
+fn default_handling<K: Resource<DynamicType = ()> + 'static>(
+    stream: impl Send + WatchStreamExt<Item = Result<watcher::Event<K>, watcher::Error>>,
+) -> impl Send + WatchStreamExt<Item = Result<K, watcher::Error>> {
+    stream
+        .modify(|g| g.managed_fields_mut().clear())
+        .touched_objects()
+        .predicate_filter(predicates::resource_version)
+        .default_backoff()
+}
+
+fn default_with_reflect<K: Resource<DynamicType = ()> + Clone + 'static>(
+    writer: Writer<K>,
+    stream: impl Send + WatchStreamExt<Item = Result<watcher::Event<K>, watcher::Error>>,
+) -> impl WatchStreamExt<Item = Result<K, watcher::Error>> {
+    stream
+        .modify(|g| g.managed_fields_mut().clear())
+        .reflect(writer)
+        .touched_objects()
+        .predicate_filter(predicates::resource_version)
+        .default_backoff()
+}
+
 pub async fn run_fleet_addon_config_controller(state: State) {
     let client = Client::try_default()
         .await
@@ -131,6 +154,7 @@ pub async fn run_fleet_addon_config_controller(state: State) {
         error_policy,
         state.to_context(client.clone()),
     )
+    .default_backoff()
     .for_each(|_| futures::future::ready(()));
 
     let dynamic_watches_controller = Controller::new(
@@ -143,6 +167,7 @@ pub async fn run_fleet_addon_config_controller(state: State) {
         error_policy,
         state.to_context(client.clone()),
     )
+    .default_backoff()
     .for_each(|_| futures::future::ready(()));
 
     let watcher = broadcaster(state.dispatcher.clone(), state.stream.clone())
@@ -180,6 +205,7 @@ pub async fn run_fleet_addon_config_controller_pre_1_32(state: State) {
             error_policy,
             state.to_context(client.clone()),
         )
+        .default_backoff()
         .for_each(|_| futures::future::ready(()));
     tokio::join!(fleet_addon_config_controller);
 }
@@ -188,8 +214,17 @@ pub async fn run_fleet_helm_controller(state: State) {
     let client = Client::try_default()
         .await
         .expect("failed to create kube Client");
-    let api: Api<FleetAddonConfig> = Api::all(client.clone());
-    let fleet_addon_config_controller = Controller::new(api, watcher::Config::default())
+    let (reader, writer) = reflector::store();
+    let fleet_addon_config = default_with_reflect(
+        writer,
+        watcher(
+            Api::<FleetAddonConfig>::all(client.clone()),
+            Config::default().any_semantic(),
+        ),
+    )
+    .predicate_filter(predicates::generation);
+
+    let fleet_addon_config_controller = Controller::for_stream(fleet_addon_config, reader)
         .shutdown_on_signal()
         .run(
             |obj, ctx| async move {
@@ -250,6 +285,7 @@ pub async fn run_fleet_helm_controller(state: State) {
             error_policy,
             state.to_context(client.clone()),
         )
+        .default_backoff()
         .for_each(|_| futures::future::ready(()));
     tokio::join!(fleet_addon_config_controller);
 }
@@ -272,27 +308,30 @@ pub async fn run_cluster_controller(state: State) {
             error_policy,
             state.to_context(client.clone()),
         )
+        .default_backoff()
         .for_each(|_| futures::future::ready(()));
 
-    let fleet = metadata_watcher(
+    let fleet = default_handling(metadata_watcher(
         Api::<fleet_cluster::Cluster>::all(client.clone()),
         Config::default().any_semantic(),
-    )
-    .modify(|g| g.managed_fields_mut().clear())
-    .touched_objects()
-    .predicate_filter(predicates::resource_version);
+    ));
 
-    let mappings = metadata_watcher(
+    let groups = default_handling(metadata_watcher(
+        Api::<ClusterGroup>::all(client.clone()),
+        Config::default()
+            .labels_from(&ClusterGroup::group_selector())
+            .any_semantic(),
+    ));
+
+    let mappings = default_handling(metadata_watcher(
         Api::<BundleNamespaceMapping>::all(client.clone()),
         Config::default().any_semantic(),
-    )
-    .modify(|g| g.managed_fields_mut().clear())
-    .touched_objects()
-    .predicate_filter(predicates::resource_version);
+    ));
 
     let (sub, reader) = state.dispatcher.subscribe();
     let clusters = Controller::for_shared_stream(sub, reader.clone())
         .owns_stream(fleet)
+        .owns_stream(groups)
         .watches_stream(mappings, move |mapping| {
             reader
                 .state()
@@ -309,6 +348,7 @@ pub async fn run_cluster_controller(state: State) {
             error_policy,
             state.to_context(client.clone()),
         )
+        .default_backoff()
         .for_each(|_| futures::future::ready(()));
 
     tokio::join!(clusters, ns_controller);
@@ -325,43 +365,41 @@ pub async fn run_cluster_controller_pre_1_32(state: State) {
         .expect("failed to get FleetAddonConfig resource");
 
     let (reader, writer) = reflector::store();
-    let clusters = watcher(
-        Api::<Cluster>::all(client.clone()),
-        Config::default()
-            .labels_from(
-                &config
-                    .cluster_watch()
-                    .expect("valid cluster label selector"),
-            )
-            .any_semantic(),
-    )
-    .default_backoff()
-    .modify(|c| {
-        c.managed_fields_mut().clear();
-    })
-    .reflect(writer)
-    .touched_objects()
-    .predicate_filter(predicates::resource_version);
+    let clusters = default_with_reflect(
+        writer,
+        watcher(
+            Api::<Cluster>::all(client.clone()),
+            Config::default()
+                .labels_from(
+                    &config
+                        .cluster_watch()
+                        .expect("valid cluster label selector"),
+                )
+                .any_semantic(),
+        ),
+    );
 
-    let fleet = metadata_watcher(
+    let fleet = default_handling(metadata_watcher(
         Api::<fleet_cluster::Cluster>::all(client.clone()),
         Config::default().any_semantic(),
-    )
-    .modify(|g| g.managed_fields_mut().clear())
-    .touched_objects()
-    .predicate_filter(predicates::resource_version);
+    ));
 
-    let mappings = metadata_watcher(
+    let groups = default_handling(metadata_watcher(
+        Api::<ClusterGroup>::all(client.clone()),
+        Config::default()
+            .labels_from(&ClusterGroup::group_selector())
+            .any_semantic(),
+    ));
+
+    let mappings = default_handling(metadata_watcher(
         Api::<BundleNamespaceMapping>::all(client.clone()),
         Config::default().any_semantic(),
-    )
-    .modify(|g| g.managed_fields_mut().clear())
-    .touched_objects()
-    .predicate_filter(predicates::resource_version);
+    ));
 
     let (invoke_reconcile, namespace_trigger) = mpsc::channel(0);
     let clusters = Controller::for_stream(clusters, reader.clone())
         .owns_stream(fleet)
+        .owns_stream(groups)
         .watches_stream(mappings, move |mapping| {
             reader
                 .state()
@@ -379,6 +417,7 @@ pub async fn run_cluster_controller_pre_1_32(state: State) {
             error_policy,
             state.to_context(client.clone()),
         )
+        .default_backoff()
         .for_each(|_| futures::future::ready(()));
 
     if config
@@ -390,25 +429,19 @@ pub async fn run_cluster_controller_pre_1_32(state: State) {
     }
 
     let (reader, writer) = reflector::store();
-    let namespaces = metadata_watcher(
-        Api::<Namespace>::all(client.clone()),
-        Config::default()
-            .labels_from(
-                &config
-                    .namespace_selector()
-                    .expect("valid namespace selector"),
-            )
-            .any_semantic(),
-    )
-    .default_backoff()
-    .modify(|ns| {
-        ns.managed_fields_mut().clear();
-        ns.annotations_mut().clear();
-        ns.labels_mut().clear();
-    })
-    .reflect(writer)
-    .touched_objects()
-    .predicate_filter(predicates::resource_version);
+    let namespaces = default_with_reflect(
+        writer,
+        metadata_watcher(
+            Api::<Namespace>::all(client.clone()),
+            Config::default()
+                .labels_from(
+                    &config
+                        .namespace_selector()
+                        .expect("valid namespace selector"),
+                )
+                .any_semantic(),
+        ),
+    );
 
     let ns_controller = Controller::for_stream(namespaces, reader)
         .shutdown_on_signal()
@@ -417,6 +450,7 @@ pub async fn run_cluster_controller_pre_1_32(state: State) {
             Cluster::ns_trigger_error_policy,
             Arc::new(Mutex::new(invoke_reconcile)),
         )
+        .default_backoff()
         .for_each(|_| futures::future::ready(()));
 
     tokio::join!(clusters, ns_controller);
@@ -428,62 +462,49 @@ pub async fn run_cluster_class_controller(state: State) {
         .await
         .expect("failed to create kube Client");
 
-    let (reader, writer) = reflector::store_shared(1024);
-    let subscriber = writer
-        .subscribe()
-        .expect("subscribe for cluster group updates successfully");
-    let fleet_groups = watcher(
+    let group_controller = Controller::new(
         Api::<ClusterGroup>::all(client.clone()),
-        Config::default().any_semantic(),
+        Config::default()
+            .labels_from(&ClusterGroup::group_selector())
+            .any_semantic(),
+    )
+    .shutdown_on_signal()
+    .run(
+        ClusterGroup::reconcile,
+        error_policy,
+        state.to_context(client.clone()),
     )
     .default_backoff()
-    .modify(|cg| {
-        cg.managed_fields_mut().clear();
-        cg.status = None;
-    })
-    .reflect_shared(writer)
-    .touched_objects()
-    .predicate_filter(predicates::resource_version)
     .for_each(|_| futures::future::ready(()));
 
-    let group_controller = Controller::for_shared_stream(subscriber.clone(), reader)
-        .shutdown_on_signal()
-        .run(
-            ClusterGroup::reconcile,
-            error_policy,
-            state.to_context(client.clone()),
-        )
-        .for_each(|_| futures::future::ready(()));
-
     let (reader, writer) = reflector::store();
-    let cluster_classes = watcher(
-        Api::<ClusterClass>::all(client.clone()),
-        Config::default().any_semantic(),
-    )
-    .default_backoff()
-    .modify(|cc| cc.managed_fields_mut().clear())
-    .reflect(writer)
-    .touched_objects()
-    .predicate_filter(predicates::resource_version);
+    let cluster_classes = default_with_reflect(
+        writer,
+        watcher(
+            Api::<ClusterClass>::all(client.clone()),
+            Config::default().any_semantic(),
+        ),
+    );
 
-    let filtered = subscriber
-        .map(|s| Ok(s.deref().clone()))
-        .predicate_filter(crate::predicates::generation_with_deletion)
-        .filter_map(|s| future::ready(s.ok().map(Arc::new)));
+    let groups = default_handling(metadata_watcher(
+        Api::<ClusterGroup>::all(client.clone()),
+        Config::default()
+            .labels_from(&ClusterGroup::group_selector())
+            .any_semantic(),
+    ));
+
     let cluster_class_controller = Controller::for_stream(cluster_classes, reader)
-        .owns_shared_stream(filtered)
+        .owns_stream(groups)
         .shutdown_on_signal()
         .run(
             ClusterClass::reconcile,
             error_policy,
             state.to_context(client.clone()),
         )
+        .default_backoff()
         .for_each(|_| futures::future::ready(()));
 
-    tokio::select! {
-        _ = fleet_groups => {},
-        _ = futures::future::join(group_controller, cluster_class_controller) => {},
-    };
+    tokio::join!(group_controller, cluster_class_controller);
 }
 
 fn error_policy(doc: Arc<impl kube::Resource>, error: &Error, ctx: Arc<Context>) -> Action {

--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -13,7 +13,6 @@ use k8s_openapi::api::core::v1::Namespace;
 use kube::api::{ApiResource, ListParams, Object, PatchParams};
 
 use kube::client::scope;
-use kube::core::SelectorExt as _;
 use kube::runtime::watcher::{self, Config};
 use kube::{api::ResourceExt, runtime::controller::Action, Resource};
 use kube::{Api, Client};

--- a/src/controllers/controller.rs
+++ b/src/controllers/controller.rs
@@ -19,6 +19,7 @@ use kube::{api::Api, client::Client, runtime::controller::Action};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
+use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -99,10 +100,13 @@ where
     Ok(Action::await_change())
 }
 
-pub(crate) async fn patch<R>(ctx: Arc<Context>, res: &mut R, pp: &PatchParams) -> PatchResult<Action>
+pub(crate) async fn patch<R>(
+    ctx: Arc<Context>,
+    res: &mut R,
+    pp: &PatchParams,
+) -> PatchResult<Action>
 where
-    R: std::fmt::Debug,
-    R: Clone + Serialize + DeserializeOwned,
+    R: Clone + Serialize + DeserializeOwned + Debug,
     R: kube::Resource<DynamicType = (), Scope = NamespaceResourceScope>,
     R: kube::ResourceExt,
 {


### PR DESCRIPTION
Current setup allows to use functionality available for k/k 1.32+ already with streaming_list() option by piggybacking type_meta population on serialization as a typed object first with k/k below 1.32.

`TypeMeta` for core types in this scenario is always populated by `k8s_openapi` implementation, even though list response does omit type_meta for the inner set of objects.

Main differentiator here, is that streaming_list uses only `watch`, which never omits type_meta of the resource, while regular watch setup issues `list` request to collect initial events.

For the `Cluster` object defined as a `CRD`, `to_dynamic_event` performs necessary conversion with type_meta population in-place.