### PR TITLE
Add missing RBAC for BundleNamespaceMapping deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "fleet-api-rs"
-version = "0.12.0-rc.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeee62f158f23f67fe7767ee47a2bd2477c26bbf8b437a6bd4dd57ba37fe30a"
+checksum = "ec26d66715e9ab648a66005f8862ee93e1db7a1a10229e2915ee54e6c1dcc47f"
 dependencies = [
  "k8s-openapi",
  "kube",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ anyhow = "1.0.96"
 base64 = "0.22.1"
 clap = { version = "4.5.32", features = ["derive"] }
 cluster-api-rs = "1.9.6"
-fleet-api-rs = "0.12.0-rc.1"
+fleet-api-rs = "0.12.0"
 async-broadcast = "0.7.2"
 pin-project = "1.1.10"
 async-stream = "0.3.6"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -108,3 +108,9 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - fleet.cattle.io
+  resources:
+  - bundlenamespacemappings
+  verbs:
+  - delete

--- a/docs/src/02_getting_started/02_configuration.md
+++ b/docs/src/02_getting_started/02_configuration.md
@@ -29,7 +29,7 @@ spec:
     server:
       inferLocal: true # Uses default `kuberenetes` endpoint and secret for APIServerURL configuration
   install:
-    version: v0.12.0-rc.1 # We will install alpha for helmapp support
+    followLatest: true
 ```
 
 ### Fleet Public URL and Certificate setup
@@ -52,7 +52,7 @@ spec:
     server:
       inferLocal: true # Uses default `kuberenetes` endpoint and secret for APIServerURL configuration
   install:
-    version: v0.12.0-rc.1 # We will install alpha for helmapp support
+    followLatest: true
 ```
 
 This scenario works well in a test setup, while using CAPI docker provider and docker clusters.

--- a/docs/src/03_tutorials/01_prerequisites.md
+++ b/docs/src/03_tutorials/01_prerequisites.md
@@ -27,8 +27,8 @@ kubectl config view -o json --raw | jq -r '.clusters[] | select(.name=="kind-dev
 # Set the API server URL
 API_SERVER_URL=`kubectl config view -o json --raw | jq -r '.clusters[] | select(.name=="kind-dev").cluster["server"]'`
 # And proceed with the installation via helm
-helm -n cattle-fleet-system install --version v0.12.0-rc.1 --create-namespace --wait fleet-crd fleet/fleet-crd
-helm install --create-namespace --version v0.12.0-rc.1 -n cattle-fleet-system --set apiServerURL=$API_SERVER_URL --set-file apiServerCA=_out/ca.pem fleet fleet/fleet --wait
+helm -n cattle-fleet-system install --version v0.12.0 --create-namespace --wait fleet-crd fleet/fleet-crd
+helm install --create-namespace --version v0.12.0 -n cattle-fleet-system --set apiServerURL=$API_SERVER_URL --set-file apiServerCA=_out/ca.pem fleet fleet/fleet --wait
 ```
 4. Install CAPI with the required experimental features enabled and initialized the Docker provider for testing.
 ```

--- a/docs/src/03_tutorials/03_installing_calico.md
+++ b/docs/src/03_tutorials/03_installing_calico.md
@@ -3,7 +3,7 @@
 <div class="warning">
 
 Note: For this setup to work, you need to install Fleet and Fleet CRDs charts via
-`FleetAddonConfig` resource. Both need to have version >= v0.12.0-rc.1,
+`FleetAddonConfig` resource. Both need to have version >= v0.12.0,
 which provides support for `HelmApp` resource.
 
 </div>

--- a/docs/src/03_tutorials/04_installing_calico_via_gitrepo.md
+++ b/docs/src/03_tutorials/04_installing_calico_via_gitrepo.md
@@ -3,7 +3,7 @@
 <div class="warning">
 
 Note: For this setup to work, you need have Fleet and Fleet CRDs charts installed
-with version >= `v0.12.0-rc.1`.
+with version >= `v0.12.0`.
 
 </div>
 
@@ -54,13 +54,7 @@ We also need to [resolve conflicts][], which happen due to in-place modification
 [previous]: ./03_installing_calico.md
 [resolve conflicts]: https://fleet.rancher.io/bundle-diffs
 
-Then we are specifying `targets.yaml` file, which will declare selection rules for this `fleet.yaml` configuration. In our case, we will match on clusters labeled with `cni: calico` label:
-
-```yaml
-{{#include ../../../fleet/applications/calico/targets.yaml}}
-```
-
-Once everything is ready, we need to apply our `GitRepo` in the `default` namespace:
+Once everything is ready, we need to apply our `GitRepo` in the `default` namespace. In our case, we will match on clusters labeled with `cni: calico` label:
 
 ```yaml
 {{#include ../../../testdata/gitrepo-calico.yaml}}

--- a/justfile
+++ b/justfile
@@ -210,6 +210,7 @@ _test-import-all:
 [private]
 _test-delete-all:
     # Verify that deleting everything causes full re-import
+    kubectl delete clustergroups.fleet.cattle.io quick-start.clusterclass --wait
     kubectl delete clustergroups.fleet.cattle.io -n clusterclass quick-start --wait
     kubectl delete bundlenamespacemappings.fleet.cattle.io -n clusterclass default --wait
     kubectl delete clusters.fleet.cattle.io capi-quickstart --wait

--- a/src/api/bundle_namespace_mapping.rs
+++ b/src/api/bundle_namespace_mapping.rs
@@ -1,10 +1,10 @@
-use std::collections::BTreeMap;
-
+use fleet_api_rs::fleet_bundle_namespace_mapping::{
+    BundleNamespaceMappingBundleSelector, BundleNamespaceMappingNamespaceSelector,
+};
 use kube::{
     api::{ObjectMeta, TypeMeta},
     Resource,
 };
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 mod mapping {
@@ -31,84 +31,4 @@ pub struct BundleNamespaceMapping {
     pub metadata: ObjectMeta,
     pub bundle_selector: BundleNamespaceMappingBundleSelector,
     pub namespace_selector: BundleNamespaceMappingNamespaceSelector,
-}
-
-/// A label selector is a label query over a set of resources. The result of matchLabels and
-/// matchExpressions are ANDed. An empty label selector matches all objects. A null
-/// label selector matches no objects.
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, JsonSchema)]
-pub struct BundleNamespaceMappingBundleSelector {
-    /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        rename = "matchExpressions"
-    )]
-    pub match_expressions: Option<Vec<BundleNamespaceMappingBundleSelectorMatchExpressions>>,
-    /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-    /// map is equivalent to an element of matchExpressions, whose key field is "key", the
-    /// operator is "In", and the values array contains only "value". The requirements are ANDed.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        rename = "matchLabels"
-    )]
-    pub match_labels: Option<BTreeMap<String, String>>,
-}
-
-/// A label selector requirement is a selector that contains values, a key, and an operator that
-/// relates the key and values.
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, JsonSchema)]
-pub struct BundleNamespaceMappingBundleSelectorMatchExpressions {
-    /// key is the label key that the selector applies to.
-    pub key: String,
-    /// operator represents a key's relationship to a set of values.
-    /// Valid operators are In, NotIn, Exists and DoesNotExist.
-    pub operator: String,
-    /// values is an array of string values. If the operator is In or NotIn,
-    /// the values array must be non-empty. If the operator is Exists or DoesNotExist,
-    /// the values array must be empty. This array is replaced during a strategic
-    /// merge patch.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub values: Option<Vec<String>>,
-}
-
-/// A label selector is a label query over a set of resources. The result of matchLabels and
-/// matchExpressions are ANDed. An empty label selector matches all objects. A null
-/// label selector matches no objects.
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, JsonSchema)]
-pub struct BundleNamespaceMappingNamespaceSelector {
-    /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        rename = "matchExpressions"
-    )]
-    pub match_expressions: Option<Vec<BundleNamespaceMappingNamespaceSelectorMatchExpressions>>,
-    /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-    /// map is equivalent to an element of matchExpressions, whose key field is "key", the
-    /// operator is "In", and the values array contains only "value". The requirements are ANDed.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        rename = "matchLabels"
-    )]
-    pub match_labels: Option<BTreeMap<String, String>>,
-}
-
-/// A label selector requirement is a selector that contains values, a key, and an operator that
-/// relates the key and values.
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, JsonSchema)]
-pub struct BundleNamespaceMappingNamespaceSelectorMatchExpressions {
-    /// key is the label key that the selector applies to.
-    pub key: String,
-    /// operator represents a key's relationship to a set of values.
-    /// Valid operators are In, NotIn, Exists and DoesNotExist.
-    pub operator: String,
-    /// values is an array of string values. If the operator is In or NotIn,
-    /// the values array must be non-empty. If the operator is Exists or DoesNotExist,
-    /// the values array must be empty. This array is replaced during a strategic
-    /// merge patch.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub values: Option<Vec<String>>,
 }

--- a/src/api/capi_cluster.rs
+++ b/src/api/capi_cluster.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use cluster_api_rs::capi_cluster::{ClusterSpec, ClusterStatus};
-use fleet_api_rs::fleet_clustergroup::{ClusterGroupSelector, ClusterGroupSpec};
+use fleet_api_rs::{fleet_bundle_namespace_mapping::BundleNamespaceMappingNamespaceSelector, fleet_clustergroup::{ClusterGroupSelector, ClusterGroupSpec}};
 use kube::{
     api::{ObjectMeta, TypeMeta},
     Resource, ResourceExt as _,
@@ -11,7 +11,7 @@ use rand::distr::{Alphanumeric, SampleString as _};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    bundle_namespace_mapping::{BundleNamespaceMapping, BundleNamespaceMappingNamespaceSelector},
+    bundle_namespace_mapping::BundleNamespaceMapping,
     fleet_addon_config::ClusterConfig,
     fleet_cluster,
     fleet_clustergroup::{ClusterGroup, CLUSTER_CLASS_LABEL, CLUSTER_CLASS_NAMESPACE_LABEL},

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -21,5 +21,5 @@ spec:
       matchLabels:
         import: ""
   install:
-    version: v0.12.0-rc.1 # We will install alpha for helmapp support
+    followLatest: true # We will install alpha for helmapp support
 


### PR DESCRIPTION
Fixing issue with cluster deletion, caused by missing permissions.

```
2025-03-24T21:56:50.759002Z ERROR reconciling object:reconcile: controller::controllers::controller: error=Finalizer Error: failed to clean up object: Fleet error: BundleNamespaceMapping delete error: ApiError: bundlenamespacemappings.fleet.cattle.io "creategitops-xj4pnq" is forbidden: User "system:serviceaccount:rancher-turtles-system:caapf-controller-manager" cannot delete resource "bundlenamespacemappings" in API group "fleet.cattle.io" in the namespace "creategitops-azure-rke2": Forbidden (ErrorResponse { status: "Failure", message: "bundlenamespacemappings.fleet.cattle.io \"creategitops-xj4pnq\" is forbidden: User \"system:serviceaccount:rancher-turtles-system:caapf-controller-manager\" cannot delete resource \"bundlenamespacemappings\" in API group \"fleet.cattle.io\" in the namespace \"creategitops-azure-rke2\"", reason: "Forbidden", code: 403 }) object.ref=Cluster.v1beta1.cluster.x-k8s.io/cluster-azure-rke2.creategitops-xj4pnq object.reason=error policy requested retry trace_id=00000000000000000000000000000000 name="cluster-azure-rke2" namespace="creategitops-xj4pnq"
```