### PR TITLE
Ensure flags update does not upgrade fleet chart

### DIFF
--- a/src/controllers/helm/install.rs
+++ b/src/controllers/helm/install.rs
@@ -186,10 +186,10 @@ impl FleetChart {
 }
 
 impl FleetOptions {
-    pub fn patch_fleet(&self) -> FleetPatchResult<Child> {
+    pub fn patch_fleet(&self, version: &str) -> FleetPatchResult<Child> {
         let mut upgrade = Command::new("helm");
 
-        upgrade.args(["upgrade", "fleet", "fleet/fleet", "--reuse-values"]);
+        upgrade.args(["upgrade", "fleet", "fleet/fleet", "--reuse-values", "--version", version]);
 
         if !self.namespace.is_empty() {
             upgrade.args(["--namespace", &self.namespace]);


### PR DESCRIPTION
It appears that in-place updating of the helm chart values to enable experimental `fleet` flags causes unintended version upgrade to the `latest` version of the chart.

This change passes current version of installed `fleet` chart to the command to update experimental flags.