### PR TITLE
Dynamic watches setup: wait until the first subscriber added

### DIFF
--- a/src/api/capi_cluster.rs
+++ b/src/api/capi_cluster.rs
@@ -1,7 +1,10 @@
 use std::collections::BTreeMap;
 
 use cluster_api_rs::capi_cluster::{ClusterSpec, ClusterStatus};
-use fleet_api_rs::{fleet_bundle_namespace_mapping::BundleNamespaceMappingNamespaceSelector, fleet_clustergroup::{ClusterGroupSelector, ClusterGroupSpec}};
+use fleet_api_rs::{
+    fleet_bundle_namespace_mapping::BundleNamespaceMappingNamespaceSelector,
+    fleet_clustergroup::{ClusterGroupSelector, ClusterGroupSpec},
+};
 use kube::{
     api::{ObjectMeta, TypeMeta},
     Resource, ResourceExt as _,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -15,7 +15,6 @@ use clap::Parser;
 use futures::stream::SelectAll;
 use futures::{Stream, StreamExt};
 
-use k8s_openapi::api::core::v1::Namespace;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, Time};
 use kube::api::{DynamicObject, Patch, PatchParams};
 use kube::core::DeserializeGuard;
@@ -33,7 +32,6 @@ use kube::{
 use kube::{Resource, ResourceExt};
 
 use std::collections::BTreeMap;
-use std::future;
 
 use std::ops::Deref;
 use std::pin::Pin;
@@ -280,10 +278,6 @@ pub async fn run_cluster_controller(state: State) {
         .expect("failed to create kube Client");
 
     let (sub, reader) = state.dispatcher.subscribe();
-    let sub = sub
-        .map(|n: Arc<Namespace>| Ok(n.deref().clone()))
-        .predicate_filter(predicates::labels)
-        .filter_map(|n| future::ready(n.ok().map(Arc::new)));
     let ns_controller = Controller::for_shared_stream(sub, reader)
         .shutdown_on_signal()
         .run(

--- a/src/controllers/helm/install.rs
+++ b/src/controllers/helm/install.rs
@@ -189,7 +189,14 @@ impl FleetOptions {
     pub fn patch_fleet(&self, version: &str) -> FleetPatchResult<Child> {
         let mut upgrade = Command::new("helm");
 
-        upgrade.args(["upgrade", "fleet", "fleet/fleet", "--reuse-values", "--version", version]);
+        upgrade.args([
+            "upgrade",
+            "fleet",
+            "fleet/fleet",
+            "--reuse-values",
+            "--version",
+            version,
+        ]);
 
         if !self.namespace.is_empty() {
             upgrade.args(["--namespace", &self.namespace]);

--- a/src/multi_dispatcher.rs
+++ b/src/multi_dispatcher.rs
@@ -3,6 +3,7 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
+    time::Duration,
 };
 
 use async_broadcast::{InactiveReceiver, Receiver, Sender};
@@ -18,6 +19,7 @@ use kube::{
 };
 use pin_project::pin_project;
 use serde::de::DeserializeOwned;
+use tokio::time::sleep;
 
 #[derive(Clone)]
 pub struct MultiDispatcher {
@@ -69,6 +71,11 @@ impl MultiDispatcher {
                 let _ = self.dispatch_tx.broadcast_direct(ev.clone()).await;
             }
         }
+    }
+
+    // Subscribers count returns the number of current receiving streams
+    pub(crate) fn subscribers_count(&self) -> usize {
+        self.dispatch_tx.receiver_count()
     }
 }
 
@@ -223,6 +230,10 @@ where
     W: Stream<Item = Result<Event<DynamicObject>>> + Unpin,
 {
     stream! {
+        while writer.subscribers_count() == 0 {
+            sleep(Duration::from_millis(100)).await;
+        }
+
         while let Some(event) = broadcast.next().await {
             match event {
                 Ok(ev) => {


### PR DESCRIPTION
In the existing dynamic watcher setup there is an issue with namespace controller predicate setup. In case when a cluster existed in a namespace before the addon provider controller starts, it does not get reconciled. It does not occur for clusters created in the matching namespace, after controller start.

This change removes label predicate which fixes the problem in testing, as well as addresses an issue occurring during namespace deletion.

Removing namespace with an imported cluster causes deletion to get stuck on not yet removed CAAPF finalizer. This is due to `patch` method creating an `v1.Event` resource in the current namespace, which fails when the namespace is marked for deletion, preventing latter finalizer removal.