### PR TITLE
Add annotations to Cluster.fleet object

### DIFF
--- a/src/api/capi_cluster.rs
+++ b/src/api/capi_cluster.rs
@@ -89,6 +89,7 @@ impl Cluster {
         let class = self.cluster_class_name();
         let ns = self.namespace().unwrap_or_default();
         let class_namespace = self.cluster_class_namespace().unwrap_or(&ns);
+        let annotations = self.annotations().clone();
         let labels = {
             let mut labels = self.labels().clone();
             if let Some(class) = class {
@@ -104,6 +105,7 @@ impl Cluster {
         fleet_cluster::Cluster {
             types: Some(TypeMeta::resource::<fleet_cluster::Cluster>()),
             metadata: ObjectMeta {
+                annotations: Some(annotations),
                 labels: Some(labels),
                 owner_references: config
                     .set_owner_references

--- a/testdata/cluster_docker_kcp.yaml
+++ b/testdata/cluster_docker_kcp.yaml
@@ -9,6 +9,8 @@ spec: {}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
+  annotations:
+    example.com/annotation: test
   labels:
     import: ""
     cni: kindnet


### PR DESCRIPTION
Copy annotations from CAPI cluster to cluster.fleet object

Proposed fix for https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/issues/235