### PR TITLE
:seedling: Update GHA workflows to replace 3rd-party actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install just
-        uses: extractions/setup-just@v2
+        run: cargo install just
       - uses: actions/checkout@v4
       - name: Build
         run: just compile
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install just
-        uses: extractions/setup-just@v2
+        run: cargo install just
       - uses: actions/checkout@v4
       - name: Test
         run: just test-unit
@@ -39,7 +39,7 @@ jobs:
       KUBE_VERSION: ${{ matrix.kube_version }}
     steps:
       - name: Install just
-        uses: extractions/setup-just@v2
+        run: cargo install just
       - name: Install kind
         uses: helm/kind-action@v1
         with:
@@ -72,7 +72,7 @@ jobs:
       KUBE_VERSION: ${{ matrix.kube_version }}
     steps:
       - name: Install just
-        uses: extractions/setup-just@v2
+        run: cargo install just
       - name: Install kind
         uses: helm/kind-action@v1
         with:
@@ -105,7 +105,7 @@ jobs:
       KUBE_VERSION: ${{ matrix.kube_version }}
     steps:
       - name: Install just
-        uses: extractions/setup-just@v2
+        run: cargo install just
       - name: Install kind
         uses: helm/kind-action@v1
         with:

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -16,26 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
 
     - name: Install mdBook
-      uses: extractions/setup-crate@v1
-      with:
-        owner: rust-lang
-        name: mdBook
-
-    - name: Install mdBook summary gen
-      uses: actions-rs/install@v0.1
-      with:
-        crate: mdbook-fs-summary
-
-    - name: Install mdBook toc
-      uses: actions-rs/install@v0.1
-      with:
-        crate: mdbook-toc
+      run: cargo install mdbook mdbook-fs-summary mdbook-toc
 
     - name: Build mdbook
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       packages: write
     steps:
       - name: Install just
-        uses: extractions/setup-just@v2
+        run: cargo install just
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -52,7 +52,7 @@ jobs:
     needs: [build]
     steps:
       - name: Install just
-        uses: extractions/setup-just@v2
+        run: cargo install just
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -30,13 +30,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: clippy
-          override: true
+      - name: Update Rustup and install clippy
+        run: |
+          rustup update
+          rustup component add clippy
 
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt


### PR DESCRIPTION
Used `cargo` and `rustup` to install CI tools. Note that this uses the default `cargo`/`rustup` versions that comes with the GHA image.

Partially addresses  #241  