### PR TITLE
Perform flags modification only in ConfigMap or install

### DIFF
--- a/src/controllers/controller.rs
+++ b/src/controllers/controller.rs
@@ -32,7 +32,7 @@ use super::{
 
 pub static FLEET_FINALIZER: &str = "fleet.addons.cluster.x-k8s.io";
 
-type DynamicStream = SelectAll<
+pub(crate) type DynamicStream = SelectAll<
     Pin<Box<dyn Stream<Item = Result<watcher::Event<DynamicObject>, watcher::Error>> + Send>>,
 >;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use controllers::{
-    addon_config::{AddonConfigSyncError, DynamicWatcherError, FleetPatchError, ConfigMapSyncError},
+    addon_config::{AddonConfigSyncError, DynamicWatcherError, FleetPatchError},
     helm, BundleError, SyncError,
 };
 use futures::channel::mpsc::TrySendError;
@@ -46,12 +46,6 @@ pub enum Error {
     // NB: awkward type because finalizer::Error embeds the reconciler error (which is this)
     // so boxing this error to break cycles
     FinalizerError(#[source] Box<kube::runtime::finalizer::Error<Error>>),
-
-    #[error("IllegalDocument")]
-    IllegalDocument,
-
-    #[error("ConfigMap sync error: {0}")]
-    ConfigMapSyncError(#[from] ConfigMapSyncError),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;


### PR DESCRIPTION
Remove direct helm chart modifications beyond chart `install` config, and merge experimental flags configuration with fleet chart installation.

Simplify conditions handling by using `get_or_insert_default`.

Flags configuration inside `ConfigMap` is refactored to ensure that code works on a valid structure, despite the custom merge of json and yaml data inside it due to downstream expectations. We also need to set condition on the resource, to display the state of the reconcile.

Fixes #250 