### PR TITLE
add github token to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,4 +63,6 @@ jobs:
           sed -i "s/dev/${TAG}/g" config/default/manager_image_patch.yaml
           just release-manifests
       - name: Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release create ${{ env.TAG }} -d --generate-notes --discussion-category "Announcements" metadata.yaml _out/addon-components.yaml


### PR DESCRIPTION
# Description

Using `gh` CLI requires passing `GITHUB_TOKEN` to the specific job (or globally): https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/actions/runs/14614358505/job/40999898044

This adds the token from secret in the job that uses `gh` for release.