### PR TITLE
Permit to open discussions on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      discussions: write
     steps:
       - name: Install just
         run: cargo install just


### PR DESCRIPTION
Following https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#overview, we need to enable `discussions: write` on the job to allow `gh` execution to pass.

Context: https://github.com/rancher-sandbox/cluster-api-addon-provider-fleet/actions/runs/14619424871/job/41016176936
```
Run gh release create v0.8.0 --generate-notes --discussion-category "Announcements" metadata.yaml _out/addon-components.yaml
HTTP 404: Discussion could not be created. Make sure you passed a valid category name. (https://api.github.com/repos/rancher-sandbox/cluster-api-addon-provider-fleet/releases/214231238)
Error: Process completed with exit code 1.
```

