### PR TITLE
Default fleet key in CM at all cases

### DIFF
--- a/src/api/fleet_addon_config.rs
+++ b/src/api/fleet_addon_config.rs
@@ -155,6 +155,7 @@ pub struct FleetSettings {
 #[serde_as]
 #[derive(Serialize, Deserialize, Default, Clone, Debug)]
 pub struct FleetSettingsSpec {
+    #[serde(default)]
     #[serde_as(as = "DisplayFromStr")]
     pub fleet: FleetChartValues,
 


### PR DESCRIPTION
There is an issue with expectations on `fleet` key in `configMap`, it should be optional:

```yaml
status:
  conditions:
  - lastTransitionTime: "2025-04-24T09:17:01Z"
    message: 'FleetAddonConfig reconcile error: Fleet chart patch error: FleetSettings
      read error: Error deserializing response: missing field `fleet` at line 1 column
      972'
```

Serde will perform defaulting on this key when missing with this change.

Will require backport to release-0.8

Ref: https://github.com/rancher/turtles/issues/1303#issue-3010695101