### PR TITLE
fix: ignore BundleNamespaceMapping not found on Cluster deletion

### DIFF
--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -220,9 +220,11 @@ impl FleetBundle for FleetClusterBundle {
                 return Ok(Action::await_change());
             }
 
-            BundleNamespaceMapping::get_api(ctx.client.clone(), mapping.get_namespace())
-                .delete(&mapping.name_any(), &DeleteParams::default())
-                .await?;
+            let bundle_namespace_mapping = BundleNamespaceMapping::get_api(ctx.client.clone(), mapping.get_namespace());
+
+            if bundle_namespace_mapping.get_opt(&mapping.name_any()).await?.is_some() {
+                bundle_namespace_mapping.delete(&mapping.name_any(), &DeleteParams::default()).await?;
+            }
         }
 
         // List all other clusters in this namespace


### PR DESCRIPTION
Fixes #366

This PR makes the code resilient against BundleNamespaceMapping deletion. We found cases in our tests where this happens and the BundleNamespaceMapping is deleted before the finalizer is removed by CAAPF.

Note that this is a rather ugly construct. I added a `get_opt` call to optionally get the BundleNamespaceMapping, and invoke `delete` only if we found one. 

Alternatively the `delete` call could just ignore the reason="NotFound" ErrorResponse, but my Rust was not up to the task.