### PR TITLE
ci: fix mdbook build

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install mdBook
-      run: cargo install mdbook mdbook-fs-summary mdbook-toc
+      run: cargo install mdbook@0.4.52 mdbook-fs-summary@0.2.1 mdbook-toc@0.14.2
 
     - name: Build mdbook
       run: |

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,6 +1,5 @@
 [book]
 language = "en"
-multilingual = false
 src = "src"
 title = "Cluster API Addon Provider Fleet"
 description = "Addon for native Fleet GitOps integration with CAPI"


### PR DESCRIPTION
This PR reverts the mdbook version and pins the other pre-processors. 
The fs-summary seem to fail with latest mdbook.

Also note `multilingual` was deprecated in mdbook 0.5.0, but was unused before, so I removed it already.