### PR TITLE
ci: re-enable caprke2 import test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,41 +90,39 @@ jobs:
         with:
           name: artifacts-import-${{ matrix.display_name }}
           path: _out/gather
-  # 
-  # CAPRKE2 missing CAPI v1.11 support
-  #
-  # test-e2e-import-rke2:
-  #   name: test-e2e-import-rke2 ${{ matrix.display_name }}
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       include:
-  #         - kube_version: "1.32.0"
-  #           display_name: "stable"
-  #         - kube_version: "1.34.0"
-  #           display_name: "latest"
-  #   env:
-  #     KUBE_VERSION: ${{ matrix.kube_version }}
-  #   steps:
-  #     - name: Install just
-  #       run: cargo install just
-  #     - name: Install kind
-  #       uses: helm/kind-action@v1
-  #       with:
-  #         install_only: true
-  #         version: v0.29.0
-  #     - uses: actions/checkout@v4
-  #     - name: Test (Import RKE2) - ${{ matrix.display_name }}
-  #       run: just test-import-rke2
-  #     - name: Collect artifacts
-  #       if: always()
-  #       run: just collect-test-import
-  #     - name: Store run artifacts
-  #       uses: actions/upload-artifact@v4
-  #       if: always()
-  #       with:
-  #         name: artifacts-import-rke2-${{ matrix.display_name }}
-  #         path: _out/gather
+
+  test-e2e-import-rke2:
+    name: test-e2e-import-rke2 ${{ matrix.display_name }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - kube_version: "1.32.0"
+            display_name: "stable"
+          - kube_version: "1.34.0"
+            display_name: "latest"
+    env:
+      KUBE_VERSION: ${{ matrix.kube_version }}
+    steps:
+      - name: Install just
+        run: cargo install just
+      - name: Install kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+          version: v0.29.0
+      - uses: actions/checkout@v4
+      - name: Test (Import RKE2) - ${{ matrix.display_name }}
+        run: just test-import-rke2
+      - name: Collect artifacts
+        if: always()
+        run: just collect-test-import
+      - name: Store run artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: artifacts-import-rke2-${{ matrix.display_name }}
+          path: _out/gather
 
   clippy:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -13,6 +13,7 @@ REFRESH_BIN := env_var_or_default('REFRESH_BIN', '1')
 
 # Test providers
 CLUSTER_API_VERSION := "v1.11.4"
+CAPRKE2_VERSION := "v0.22.0"
 
 export PATH := "_out:_out/bin:" + env_var('PATH')
 
@@ -166,7 +167,7 @@ install-fleet: _create-out-dir
 
 # Install cluster api and any providers
 install-capi: _download-clusterctl
-    EXP_CLUSTER_RESOURCE_SET=true CLUSTER_TOPOLOGY=true clusterctl init --core cluster-api:{{CLUSTER_API_VERSION}} -i docker:{{CLUSTER_API_VERSION}} -b rke2 -c rke2 -b kubeadm:{{CLUSTER_API_VERSION}} -c kubeadm:{{CLUSTER_API_VERSION}}
+    EXP_CLUSTER_RESOURCE_SET=true CLUSTER_TOPOLOGY=true clusterctl init --core cluster-api:{{CLUSTER_API_VERSION}} -i docker:{{CLUSTER_API_VERSION}} -b rke2:{{CAPRKE2_VERSION}} -c rke2:{{CAPRKE2_VERSION}} -b kubeadm:{{CLUSTER_API_VERSION}} -c kubeadm:{{CLUSTER_API_VERSION}}
 
 # Deploy will deploy the operator
 deploy features="": _download-kustomize

--- a/testdata/cluster_docker_rke2.yaml
+++ b/testdata/cluster_docker_rke2.yaml
@@ -42,13 +42,13 @@ spec:
       customImage: kindest/node:v1.34.0
       bootstrapTimeout: 15m
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: docker-demo-control-plane
 spec:
   replicas: 1
-  version: v1.34.0+rke2r1
+  version: v1.34.3+rke2r1
   rolloutStrategy:
     rollingUpdate:
       maxSurge: 1
@@ -65,16 +65,13 @@ spec:
       kubernetesComponents:
       - cloudController
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: DockerMachineTemplate
-      name:  docker-demo-control-plane
-    nodeDrainTimeout: 30s
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-    kind: DockerMachineTemplate
-    name:  docker-demo-control-plane
-  nodeDrainTimeout: 30s
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: DockerMachineTemplate
+        name:  docker-demo-control-plane
+      deletion:
+        nodeDrainTimeoutSeconds: 30
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
@@ -86,7 +83,7 @@ spec:
       customImage: kindest/node:v1.34.0
       bootstrapTimeout: 15m
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: RKE2ConfigTemplate
 metadata:
   name: docker-demo-md-0
@@ -104,7 +101,7 @@ spec:
       cluster.x-k8s.io/cluster-name: docker-demo
   template:
     spec:
-      version: v1.34.0+rke2r1
+      version: v1.34.3+rke2r1
       clusterName: docker-demo
       bootstrap:
         configRef:


### PR DESCRIPTION
This PR re-enables CAPRKE2 import test using v0.22.0 with support for CAPI v1.11