### PR TITLE
fix: use tigera-operator namespace to prevent rbac issues

### DIFF
--- a/fleet/applications/calico/fleet.yaml
+++ b/fleet/applications/calico/fleet.yaml
@@ -1,3 +1,4 @@
+defaultNamespace: tigera-operator
 helm:
   releaseName: projectcalico
   repo: https://docs.tigera.io/calico/charts
@@ -17,11 +18,3 @@ helm:
             encapsulation: None
             natOutgoing: Enabled
             nodeSelector: all()${- end}
-
-diff:
-  comparePatches:
-  - apiVersion: operator.tigera.io/v1
-    kind: Installation
-    name: default
-    operations:
-    - {"op":"remove", "path":"/spec/kubernetesProvider"}

--- a/testdata/helm.yaml
+++ b/testdata/helm.yaml
@@ -3,6 +3,7 @@ kind: HelmOp
 metadata:
   name: calico
 spec:
+  defaultNamespace: tigera-operator
   helm:
     releaseName: projectcalico
     repo: https://docs.tigera.io/calico/charts


### PR DESCRIPTION
The tigera-operator pod seems to be hanging in e2e tests. It seems due to https://github.com/projectcalico/calico/issues/10906

As workaround, the `tigera-operator` namespace can be used to install the chart.