### PR TITLE
ci: retry kubectl download a few times

### DIFF
--- a/justfile
+++ b/justfile
@@ -328,8 +328,18 @@ _download-kubectl: _create-out-dir
     set -euxo pipefail
     [ -z `which kubectl` ] || [ {{REFRESH_BIN}} != "0" ] || exit 0
     cd {{OUT_DIR}}
-    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/{{ARCH}}/kubectl"
-    chmod +x kubectl
+    retries=3
+    while ((retries > 0)); do
+    if curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/{{ARCH}}/kubectl"; then
+        chmod +x kubectl
+        exit 0
+    fi
+    ((retries --))
+    sleep 10s
+    done
+        echo "Failed to install kubectl"
+        exit 1
+
 
 [private]
 [macos]
@@ -338,5 +348,15 @@ _download-kubectl: _create-out-dir
     set -euxo pipefail
     [ -z `which kubectl` ] || [ {{REFRESH_BIN}} != "0" ] || exit 0
     cd {{OUT_DIR}}
-    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/{{ARCH}}/kubectl"
-    chmod +x kubectl
+    retries=3
+    while ((retries > 0)); do
+    if curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/{{ARCH}}/kubectl"; then
+        chmod +x kubectl
+        exit 0
+    fi
+    ((retries --))
+    sleep 10s
+    done
+        echo "Failed to install kubectl"
+        exit 1
+


### PR DESCRIPTION
CI very often fails downloading kubectl:

```
rm -rf _out || true
mkdir -p _out
++ which kubectl
+ '[' -z /opt/hostedtoolcache/kind/v0.29.0/amd64/kubectl/bin//kubectl ']'
+ '[' 1 '!=' 0 ']'
+ cd _out
++ curl -L -s https://dl.k8s.io/release/stable.txt
+ curl -LO 'https://dl.k8s.io/release/Timed out while waiting on cache-iad-kiad7000107-IAD
/bin/linux/amd64/kubectl'
curl: Failed to extract a sensible file name from the URL to use for storage
curl: (3) URL using bad/illegal format or missing URL
error: Recipe `_download-kubectl` failed with exit code 3
Error: Process completed with exit code 3.
```

This is a mitigation attempt to retry a few more times.