### PR TITLE
force server-side Apply patch for Fleet Clusters

### DIFF
--- a/src/controllers/cluster.rs
+++ b/src/controllers/cluster.rs
@@ -179,10 +179,12 @@ impl FleetBundle for FleetClusterBundle {
         }
 
         if self.config.cluster_patch_enabled() {
+            let mut patch_params = PatchParams::apply("addon-provider-fleet");
+            patch_params.force = true;
             patch(
                 ctx.clone(),
                 cluster,
-                &PatchParams::apply("addon-provider-fleet"),
+                &patch_params,
             )
             .await?
         } else {


### PR DESCRIPTION
Fixes #430

I tried to reproduce this by:

1. Adding a `foo=bar` label to the CAPI Cluster
2. Waiting for CAAPF to propagate the `foo=bar` label to the Fleet Cluster (immediately)
3. Overwriting the label to `foo=foo` on the Fleet Cluster.

Normally this leads to an unresolvable conflict, but with the forced patch the Fleet Cluster is reconciled as expected.