### PR TITLE
fix: address supply chain vulnerabilities

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install just
-        run: cargo install just
+        run: cargo install just@1.49.0
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build
         run: just compile
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install just
-        run: cargo install just
+        run: cargo install just@1.49.0
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Test
         run: just test-unit
@@ -43,7 +43,7 @@ jobs:
       KUBE_VERSION: ${{ matrix.kube_version }}
     steps:
       - name: Install just
-        run: cargo install just
+        run: cargo install just@1.49.0
       - name: Install kind
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
@@ -76,7 +76,7 @@ jobs:
       KUBE_VERSION: ${{ matrix.kube_version }}
     steps:
       - name: Install just
-        run: cargo install just
+        run: cargo install just@1.49.0
       - name: Install kind
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
@@ -109,7 +109,7 @@ jobs:
       KUBE_VERSION: ${{ matrix.kube_version }}
     steps:
       - name: Install just
-        run: cargo install just
+        run: cargo install just@1.49.0
       - name: Install kind
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       packages: write
     steps:
       - name: Install just
-        run: cargo install just
+        run: cargo install just@1.49.0
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -53,7 +53,7 @@ jobs:
     needs: [build]
     steps:
       - name: Install just
-        run: cargo install just
+        run: cargo install just@1.49.0
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -36,7 +36,7 @@ jobs:
           rustup component add clippy
 
       - name: Install required cargo
-        run: cargo install clippy-sarif sarif-fmt
+        run: cargo install clippy-sarif@0.8.0 sarif-fmt@0.8.0
 
       - name: Run rust-clippy
         run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,22 @@
+# renovate: datasource=github-release-attachments depName=rust-lang/rustup
+ARG RUSTUP_VERSION=1.29.0
+# renovate: datasource=github-release-attachments depName=rust-lang/rustup digestVersion=1.29.0
+ARG RUSTUP_SUM_arm64=9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792
+# renovate: datasource=github-release-attachments depName=rust-lang/rustup digestVersion=1.29.0
+ARG RUSTUP_SUM_amd64=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
+
 FROM --platform=${BUILDPLATFORM} ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5 AS build-arm64
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
+ARG RUSTUP_VERSION
+ARG RUSTUP_SUM_arm64
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --target aarch64-unknown-linux-musl  --default-toolchain stable
+RUN curl --proto '=https' --tlsv1.2 -sSfL -o /tmp/rustup-init \
+    "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/aarch64-unknown-linux-gnu/rustup-init" && \
+    echo "${RUSTUP_SUM_arm64}  /tmp/rustup-init" | sha256sum -c - && \
+    chmod +x /tmp/rustup-init && \
+    /tmp/rustup-init -y --target aarch64-unknown-linux-musl --default-toolchain stable && \
+    rm /tmp/rustup-init
 
 ENV PATH=/root/.cargo/bin:$PATH
 RUN cargo --version
@@ -19,8 +33,15 @@ RUN cargo install --locked --target aarch64-unknown-linux-musl --features=${feat
 FROM --platform=${BUILDPLATFORM} ghcr.io/cross-rs/x86_64-unknown-linux-musl:0.2.5 AS build-amd64
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
+ARG RUSTUP_VERSION
+ARG RUSTUP_SUM_amd64
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --target x86_64-unknown-linux-musl  --default-toolchain stable
+RUN curl --proto '=https' --tlsv1.2 -sSfL -o /tmp/rustup-init \
+    "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init" && \
+    echo "${RUSTUP_SUM_amd64}  /tmp/rustup-init" | sha256sum -c - && \
+    chmod +x /tmp/rustup-init && \
+    /tmp/rustup-init -y --target x86_64-unknown-linux-musl --default-toolchain stable && \
+    rm /tmp/rustup-init
 
 ENV PATH=/root/.cargo/bin:$PATH
 RUN cargo --version


### PR DESCRIPTION
- Dockerfile: replace curl|sh rustup install using SHA256 checksum validation
- Pin rustup to v1.29.0 with Renovate annotations for future updates
- pin 'cargo install just'
- pin 'cargo install clippy-sarif sarif-fmt'